### PR TITLE
fix(gameplay): close the parity gaps a line-by-line re-read of gen1recomp found

### DIFF
--- a/docs/VOXEL.md
+++ b/docs/VOXEL.md
@@ -657,7 +657,21 @@ only clock; tile animation and menu cursors derive from it.
    anchors were re-based 2026-08-06 with that bound in hand. (A
    rank-preserving order was tried first specifically to hold the anchor;
    neighbour-cell border ties move regardless, so the ceremony was paid
-   rather than the uniformity constraint weakened.)
+   rather than the uniformity constraint weakened.) A **GAMEPLAY** change is
+   the third and plainest re-basing event, and it is the only one that moves
+   both rungs for the same reason: the tape is intent, so when the guest
+   legitimately does something different the op stream itself is different
+   and every hash downstream of it follows. It still owes the same proof —
+   which marks moved, and why each one had to. The 2026-08-07 parity pass
+   (§11) moved **3 of the 15 marks**: `battle-intro` at both rungs, because
+   a two-line message page now shows BOTH of its lines (the finished row
+   went from a clobbered `uiText` to grid tiles); and `encounter-seen` /
+   `escaped` at both rungs, because the battle screen is now torn down
+   before the post-battle hold instead of staying up through it, so the
+   mark lands on the map rather than on the battle. The other twelve are
+   byte-identical, which is itself the evidence that the overworld changes
+   in that pass — cues, deferred seam music, the bump poll, the map-script
+   dispatch — are audible or behavioural but not pictorial.
 
 ## 8. Audio
 
@@ -795,12 +809,113 @@ Later rungs, in dependency order: the GB UI colour layer (a `uiPal` op — the
 one piece of RED++ parity that needs a new op); pak slimming for the
 PSP-1000's 24 MB and the frame budget together
 (hull instancing over the STMP per-cell range, which is the only cut left for
-the carved trees the distance dial cannot reach; per-map streaming); the arena
+the carved trees the distance dial cannot reach; per-map streaming);
+**neighbour-map NPC ghosts** (§11); the arena
 clearance walk (needs cook-time heights in gamedata) and the authored arena
-table; the full script verb set and story flags; trainer battles + AI
+table; the rest of the script verb set and the story cutscenes (§11);
+trainer battles + AI
 layers; the desk-set templates, stairs, and detected props; battle move
 animations; the box system, marts, and the start menu; Blue/Yellow manifests;
 first/third person; link play never.
 
 Stadium battle models are **permanently out of scope** — they require an N64
 ROM this pipeline does not accept.
+
+## 11. The parity pass (2026-08-07)
+
+A line-by-line re-read of the port against `gen1recomp` at HEAD `f0ed2ef`,
+subsystem by subsystem, with every claimed divergence checked twice at its
+cited lines on both sides. The rules modules came through clean — damage,
+crit, accuracy, the type chart, catching, exp, growth, collision, ledges and
+connections are the Lua's arithmetic verbatim. Everything the pass found was
+in the glue: a surface contract used the wrong way, registry entries never
+made, and cues fired from the wrong moment.
+
+**Fixed here.**
+
+- **`uiText` is one live run, and a finished row is not it.** The spec says
+  the core retains only the last `uiText` (§ui). The guest emitted one per
+  row, so on every two-line page the first line went blank the instant the
+  second began typing — nearly every sign, NPC line and battle message in
+  the shipped maps. Finished rows are stamped into the retained grid now
+  (glyph codes ARE ui tile ids), and only the typing row is a `uiText`. The
+  YES/NO labels had the same shape; they are grid tiles too.
+- **The string that crosses the boundary is cell-exact.** `'s` is one glyph
+  to the guest (Font.lua:262 matches digraphs greedily) and two characters
+  to the surface, so a reveal stopped one cell short and a padded row ran
+  one cell wide: "Can't escape!" printed as "Can't escape". The cook mints a
+  code point per multi-character charmap entry (`LIGATURE_BASE + code`) and
+  `toCells` emits it.
+- **Two reachable move effects were unregistered.** `SPEED_DOWN1_EFFECT`
+  (WEEDLE's STRING SHOT, Route 2 grass) printed "But, it failed!" every
+  time and never touched the speed stage; `POISON_SIDE_EFFECT1` (POISON
+  STING) could never poison. The census was re-derived from the cooked map
+  set rather than patched — `DEFENSE_UP1_EFFECT`, `FLINCH_SIDE_EFFECT1`,
+  `TWO_TO_FIVE_ATTACKS_EFFECT` and `FOCUS_ENERGY_EFFECT` become reachable
+  once a caught mon grinds, and are registered too.
+- **`EvolveAfterBattle` was never wired.** `battle.leveledUp` was written
+  and never read, so a SQUIRTLE that reached 16 on Route 1 stayed a
+  SQUIRTLE forever (the offer is gated on levelling *this* battle, so there
+  is no catching up later). `Evolution.checkParty`'s decision half is
+  ported; `game.ts` runs the pages, the apply and the evolved species'
+  exact-level learn check on the way out of a battle.
+- **The hand-ported map scripts have a call site.** The 8-verb runner had
+  no caller: `showMapText` went straight to extracted text, and a text_asm
+  pointer extracts only its FIRST branch — so Mom offered the wake-up line
+  to a trainer who already had a starter, forever, and Oak never stopped
+  barring the grass. `world/mapscripts.ts` carries the scripts for the maps
+  this pak cooks, transcribed from `data/scripts/`, and the verb set grew
+  to what they invoke (`check_flag`, `jump`/`jump_if_true`/`jump_if_false`,
+  `label`, `face_player`, `heal_party`, `play_once`, `fade`). Jump targets
+  resolve by row, by label and by `"end"`; a re-entrant `resume` lands the
+  pending yield instead of throwing; an unknown verb logs the row it drops.
+- **Cues fire where the reference fires them.** The battle now queues its
+  audio at the Lua's own call sites and the shell drains that queue, which
+  fixed three orderings at once: the wild mon's cry sounded before the
+  silhouettes had landed, the victory theme a text box late, the map theme
+  ten ticks after teardown. The field cues that were simply absent are in:
+  `Collision` on a wall bonk (with its 16-frame cooldown), `Ledge` on a
+  hop, `Go_Inside`/`Go_Outside` on a door warp. A connection crossing
+  defers the new map's theme to the frame the seam step LANDS.
+- **The post-battle hand-back is the map's, not the battle's.** The battle
+  screen is torn down at teardown, and it is the map that pays
+  POST_BATTLE_RETURN and then MapEntryAfterBattle's 24 frames.
+- **YES/NO answers hold.** Both branches of `DisplayTwoOptionMenu` hold 15
+  frames with the menu up, and B snaps the cursor to NO first — in the
+  overworld box and in the battle's, which also owed the A/B beep.
+- **Smaller ones.** The content-boundary bump ends the direction poll
+  instead of continuing it (a held diagonal walked on the other axis, and
+  the turn-in-place flag re-armed mid-hold); a locked warp no longer leaks
+  `doorWarp` into the next one, and resumes a parked script instead of
+  stranding it; border-extended tile reads use a floored modulo, as Lua's
+  `%` does; the ball chain hides the wild mon while the ball shakes
+  (`HIDEPIC`/`SHOWPIC` are engine state, not animation state).
+
+**Found, not fixed, and why.**
+
+- **Neighbour-map NPC ghosts.** Upstream keeps connected maps' objects
+  alive and ticking so a connected map is not empty and an NPC that
+  wandered while you were away is where it should be at the seam
+  (`OverworldController.lua:533` ghosts, ticked at :1039, drawn at :4738).
+  The port builds only the current map's list. The port already draws the
+  neighbours' terrain, so the gap is visible — but the fix spends entity
+  slots against a 16-slot budget on a machine whose frame is already
+  locked, so it wants its own pass with a hardware measurement, not a
+  drive-by.
+- **`TWINEEDLE_EFFECT` and `SWITCH_AND_TELEPORT_EFFECT`.** Reachable at
+  L19-20 on a caught mon. The first wants the per-hit seam its poison
+  reroute uses; the second ends the wild battle from inside a move, which
+  is a battle-exit path this slice does not have.
+- **Item balls, and the ball supply.** ROUTE_2's two item-ball objects are
+  inert, and with no reachable ball source the fully-ported catch path is
+  dead content in the shipped build. Both want the item-object interaction
+  upstream has, which is the same seam marts and the start menu sit behind.
+- **ROM wording for three lines.** The learn-move, confusion-wears-off and
+  paralysis lines print the Lua's own fallback templates rather than
+  resolving the ROM label. The port declares this adaptation for the pure
+  rules modules (`rules/status.ts`); making it consistent means porting
+  `RomText` and sweeping every call site, which is a pass of its own.
+- **One RNG stream vs three.** Upstream runs every gameplay roll through
+  one generator; the port partitions three seeded streams so ambience and
+  battles cannot perturb the route. Changing the topology would move every
+  committed hash to buy nothing a player could see. Kept, deliberately.

--- a/tests/goldens/voxel/battle-max.hashes
+++ b/tests/goldens/voxel/battle-max.hashes
@@ -1,4 +1,4 @@
 grass-edge 5cdf2faa897170fe
-battle-intro c14cb7dc77e43b67
+battle-intro 3fd69081d39ec1fa
 post-fight 2052f0bbb9409607
-escaped 17cfbfa23bb57f63
+escaped a446ef89e8cac862

--- a/tests/goldens/voxel/battle.hashes
+++ b/tests/goldens/voxel/battle.hashes
@@ -1,4 +1,4 @@
 grass-edge 05ec5a1c88eaa110
-battle-intro 489c86809fea0f8b
+battle-intro 3851babac1f92012
 post-fight 814e865afea4cef8
-escaped b573e8b6e18e153c
+escaped f34d19be013da10e

--- a/tests/goldens/voxel/story-max.hashes
+++ b/tests/goldens/voxel/story-max.hashes
@@ -6,6 +6,6 @@ oaks-lab ec83099c3c04cdc7
 lab-exit c802b7b6eb4316e6
 route-1 412207abece8c8fe
 mid-route da7b8dbd03763065
-encounter-seen 17cfbfa23bb57f63
+encounter-seen a446ef89e8cac862
 viridian f1ee2980b00fcca9
 done 82ec257205f00b85

--- a/tests/goldens/voxel/story.hashes
+++ b/tests/goldens/voxel/story.hashes
@@ -6,6 +6,6 @@ oaks-lab 84f89fb9fd1627f1
 lab-exit 6f92255db209a8cd
 route-1 0ab5780ac3477e50
 mid-route c2afe041b859d948
-encounter-seen b573e8b6e18e153c
+encounter-seen f34d19be013da10e
 viridian d7dba9ad7bf7ce8c
 done dc0698a0c5840281

--- a/tests/voxel-parity.test.ts
+++ b/tests/voxel-parity.test.ts
@@ -1,0 +1,313 @@
+// tests/voxel-parity.test.ts — the behaviors a line-by-line audit against
+// gen1recomp found the port had drifted on, pinned so they cannot drift back.
+//
+// Layer 1 (ROM-free): the glyph/cell boundary and the script runner's
+// branching. Layer 2 (gated on dist/voxelmon/gen): the effect registry over
+// the real move table, the hand-ported talk scripts over the real text
+// pointers, and the after-battle evolution hook.
+
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+import { VOX_BTN, VOX_OP } from "../contracts/spec/voxel-spec.ts";
+import { EFFECTS } from "../voxelmon/game/battle/effects.ts";
+import { newMon } from "../voxelmon/game/battle/mon.ts";
+import { loadRuntimeData, REQUIRED_MODULES, type VoxelmonData } from "../voxelmon/game/data.ts";
+import { VoxelmonGame } from "../voxelmon/game/game.ts";
+import { RecorderHost } from "../voxelmon/game/host.ts";
+import { checkParty } from "../voxelmon/game/rules/evolution.ts";
+import { encodeGlyphs, glyphLen, LIGATURE_BASE, toCells } from "../voxelmon/game/ui/tiles.ts";
+import { MAP_SCRIPTS, talkScript } from "../voxelmon/game/world/mapscripts.ts";
+import { ScriptRunner, type ScriptRow, type ScriptWorld } from "../voxelmon/game/world/script.ts";
+
+const root = join(import.meta.dir, "..");
+const genDir = join(root, "dist/voxelmon/gen");
+const hasGen = REQUIRED_MODULES.every((m) => existsSync(join(genDir, `${m}.json`)));
+if (!hasGen) {
+  console.log("[voxel-parity] dist/voxelmon/gen absent — ROM-gated suites skipped");
+}
+const romData: VoxelmonData | null = hasGen ? await loadRuntimeData(genDir) : null;
+
+// ---------------------------------------------------------------------------
+// The glyph/cell boundary (Font.lua:262 split + :358 advanceOf)
+// ---------------------------------------------------------------------------
+
+describe("uiText is cell-exact", () => {
+  test("a ligature is one glyph AND one code unit", () => {
+    // "Can't escape!" — the run-failed line. 13 source characters, 12 cells:
+    // `'t` is one glyph on the GB, so a source-string reveal stopped one cell
+    // short and the "!" never appeared.
+    const line = "Can't escape!";
+    expect(line.length).toBe(13);
+    expect(glyphLen(line)).toBe(12);
+    expect(toCells(line).length).toBe(glyphLen(line));
+  });
+
+  test("every v1 ligature survives the crossing", () => {
+    for (const line of [
+      "Don't go out!",
+      "DIGLETT's CAVE",
+      "It's unsafe!",
+      "PROF.OAK's AIDE.",
+    ]) {
+      expect(toCells(line).length).toBe(glyphLen(line));
+    }
+  });
+
+  test("a digraph takes a minted code point, plain text stays itself", () => {
+    expect(toCells("ABC")).toBe("ABC");
+    const cells = toCells("It's");
+    expect(cells.length).toBe(3);
+    // 0xbd is the charmap code for `'s` (tiles.ts CHARMAP_PAIRS)
+    expect(cells.charCodeAt(2)).toBe(LIGATURE_BASE + 0xbd);
+  });
+
+  test("an unmapped character still costs exactly one cell", () => {
+    expect(toCells("AB").length).toBe(glyphLen("AB"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The retained-grid discipline (voxel-spec §ui: uiText is the ONE live run)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasGen)("a finished text row lives in the tile grid", () => {
+  test("row 1 is stamped into the grid and never a second uiText", () => {
+    const host = new RecorderHost();
+    const game = new VoxelmonGame(romData!, host, 1);
+    game.newGame();
+    game.showText("HELLO THERE\nSECOND LINE");
+    for (let i = 0; i < 240; i++) game.tick(0);
+
+    // group the op stream by tick (`t <tick> <buttons>` opens each frame)
+    const ticks: string[][] = [];
+    for (const line of host.text().split("\n")) {
+      if (line.startsWith("t ")) ticks.push([]);
+      else if (ticks.length) ticks[ticks.length - 1]!.push(line);
+    }
+    // THE invariant: the core retains only the LAST uiText of a tick, so two
+    // in one tick means the earlier row went blank on screen.
+    for (const ops of ticks) {
+      const texts = ops.filter((o) => o.startsWith(`s ${VOX_OP.uiText} `));
+      expect(texts.length).toBeLessThanOrEqual(1);
+    }
+    // and the finished row IS on screen: its glyphs went out as uiTile ops
+    // on the first text row (LINE1_Y = 14)
+    const stamped = new Set(
+      ticks
+        .flat()
+        .filter((o) => o.startsWith(`o ${VOX_OP.uiTile} `))
+        .map((o) => o.split(" "))
+        .filter((p) => Number(p[3]) === 14)
+        .map((p) => Number(p[4])),
+    );
+    for (const code of encodeGlyphs("HELLO THERE")) expect(stamped.has(code)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The move-effect registry (MoveEffects.lua) over the cooked map set
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasGen)("every reachable move effect is registered", () => {
+  test("the wilds of the cooked routes have no unimplemented effect", () => {
+    const data = romData!;
+    // ROUTE_1 / ROUTE_2 grass, the only wild content this pak carries
+    const wilds = new Map<string, number>();
+    for (const map of ["ROUTE_1", "ROUTE_2"]) {
+      const enc = (data.encounters as Record<string, { grass?: { slots: { species: string; level: number }[] } }>)[map];
+      for (const slot of enc?.grass?.slots ?? []) {
+        wilds.set(slot.species, Math.max(wilds.get(slot.species) ?? 0, slot.level));
+      }
+    }
+    expect(wilds.size).toBeGreaterThan(0);
+    const missing: string[] = [];
+    for (const [species, level] of wilds) {
+      const def = data.pokemon[species]!;
+      const moves = new Set<string>(def.level1Moves ?? []);
+      for (const row of def.learnset ?? []) {
+        if (row.level <= level) moves.add(row.move);
+      }
+      for (const id of moves) {
+        const effect = data.moves[id]?.effect;
+        if (effect && !EFFECTS[effect]) missing.push(`${species} ${id} -> ${effect}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  test("STRING SHOT and POISON STING resolve to their handlers", () => {
+    // WEEDLE's level-1 pair, reachable in ROUTE_2 grass: unregistered, the
+    // first printed "But, it failed!" and the second could never poison.
+    expect(EFFECTS.SPEED_DOWN1_EFFECT?.kind).toBe("primary");
+    expect(EFFECTS.SPEED_DOWN1_EFFECT?.accuracyChecked).toBe(true);
+    expect(EFFECTS.POISON_SIDE_EFFECT1?.kind).toBe("secondary");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The script runner's branching (ScriptRunner.lua:143 exec)
+// ---------------------------------------------------------------------------
+
+function stubWorld(flags: Record<string, boolean>, shown: string[]): ScriptWorld {
+  return {
+    data: { text: {}, moves: {}, pokemon: {}, items: {} } as unknown as VoxelmonData,
+    save: { flags, inventory: {}, player: { name: "RED", rival: "BLUE" } },
+    showText(text, onDone) {
+      shown.push(text);
+      onDone();
+    },
+    showChoice(text, choice) {
+      shown.push(text);
+      choice(true);
+    },
+    resolveText: () => null,
+    startWarpTo: (_m, _x, _y, _f, onDone) => onDone(),
+    scriptMove: (_e, _d, _t, onDone) => onDone?.(),
+    player: { moving: false },
+    setEmote: (_e, _b, _f, onDone) => onDone(),
+    healParty() {
+      shown.push("<heal>");
+    },
+    playOnce(song, onDone) {
+      shown.push(`<song ${song}>`);
+      onDone();
+    },
+    fade(dir, _frames, onDone) {
+      shown.push(`<fade ${dir}>`);
+      onDone();
+    },
+    facePlayer() {
+      shown.push("<face>");
+    },
+  };
+}
+
+/**
+ * Drive a runner to completion the way the overworld's update loop does. A
+ * talk script always has a talking NPC — face_player is a no-op without one
+ * (Commands.lua:162), so the stub hands one in.
+ */
+function runToEnd(world: ScriptWorld, script: ScriptRow[]): void {
+  const runner = new ScriptRunner(world);
+  runner.run(script, { npc: {} as never });
+  for (let i = 0; i < 64 && runner.isRunning(); i++) runner.update();
+}
+
+describe("script branching", () => {
+  test("check_flag + jump_if_true takes the second branch", () => {
+    const shown: string[] = [];
+    runToEnd(stubWorld({ EVENT_GOT_STARTER: true }, shown), MAP_SCRIPTS.REDS_HOUSE_1F!.talk!
+      .TEXT_REDSHOUSE1F_MOM!);
+    // the heal branch, in the Lua's order (reds_house.lua rows 6-11)
+    expect(shown).toEqual([
+      "<face>",
+      "_RedsHouse1FMomYouShouldRestText",
+      "<fade out>",
+      "<heal>",
+      "<song Music_PkmnHealed>",
+      "<fade in>",
+      "_RedsHouse1FMomLookingGreatText",
+    ]);
+  });
+
+  test("the cleared flag takes the wake-up branch and halts on jump end", () => {
+    const shown: string[] = [];
+    runToEnd(stubWorld({}, shown), MAP_SCRIPTS.REDS_HOUSE_1F!.talk!.TEXT_REDSHOUSE1F_MOM!);
+    expect(shown).toEqual(["<face>", "_RedsHouse1FMomWakeUpText"]);
+  });
+
+  test("Oak's two branches", () => {
+    const after: string[] = [];
+    runToEnd(stubWorld({ EVENT_GOT_STARTER: true }, after), MAP_SCRIPTS.PALLET_TOWN!.talk!
+      .TEXT_PALLETTOWN_OAK!);
+    expect(after).toEqual(["<face>", "_PalletTownOakItsUnsafeText"]);
+    const before: string[] = [];
+    runToEnd(stubWorld({}, before), MAP_SCRIPTS.PALLET_TOWN!.talk!.TEXT_PALLETTOWN_OAK!);
+    expect(before).toEqual(["<face>", "_PalletTownOakHeyWaitDontGoOutText"]);
+  });
+
+  test("a label is a jump target", () => {
+    const shown: string[] = [];
+    runToEnd(stubWorld({}, shown), [
+      ["jump", "tail"],
+      ["show_text", "skipped"],
+      ["label", "tail"],
+      ["show_text", "tail-ran"],
+    ]);
+    expect(shown).toEqual(["tail-ran"]);
+  });
+
+  test("an unknown verb is skipped, not fatal", () => {
+    const shown: string[] = [];
+    runToEnd(stubWorld({}, shown), [["no_such_verb", 1], ["show_text", "still-here"]]);
+    expect(shown).toEqual(["still-here"]);
+  });
+});
+
+describe.skipIf(!hasGen)("the talk dispatch reaches the real text", () => {
+  test("Mom's script is registered for the map the pak cooks", () => {
+    expect(talkScript("REDS_HOUSE_1F", "TEXT_REDSHOUSE1F_MOM")).not.toBeNull();
+    expect(talkScript("REDS_HOUSE_1F", "TEXT_NOT_A_THING")).toBeNull();
+  });
+
+  test("both of Mom's branch labels exist in the extracted text", () => {
+    const text = romData!.text as Record<string, string>;
+    for (const label of [
+      "_RedsHouse1FMomWakeUpText",
+      "_RedsHouse1FMomYouShouldRestText",
+      "_RedsHouse1FMomLookingGreatText",
+      "_PalletTownOakHeyWaitDontGoOutText",
+      "_PalletTownOakItsUnsafeText",
+    ]) {
+      expect(typeof text[label]).toBe("string");
+    }
+  });
+
+  test("a new game starts past the lab, so the branches resolve that way", () => {
+    const game = new VoxelmonGame(romData!, new RecorderHost(), 1);
+    game.newGame();
+    expect(game.save.flags.EVENT_GOT_STARTER).toBe(true);
+    expect(game.save.party.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EvolveAfterBattle (Evolution.lua:195 checkParty)
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!hasGen)("evolution after a battle", () => {
+  test("only a mon that leveled THIS battle is offered", () => {
+    const data = romData!;
+    const grown = newMon(data, "SQUIRTLE", 16);
+    const idle = newMon(data, "SQUIRTLE", 16);
+    expect(checkParty(data, [grown, idle], new Set([grown]))).toEqual([
+      { mon: grown, to: "WARTORTLE", evo: expect.anything() },
+    ]);
+    expect(checkParty(data, [grown, idle], null)).toEqual([]);
+  });
+
+  test("below the level nothing is pending", () => {
+    const data = romData!;
+    const young = newMon(data, "SQUIRTLE", 15);
+    expect(checkParty(data, [young], new Set([young]))).toEqual([]);
+  });
+
+  test("the hook runs on the way out of a battle", () => {
+    const data = romData!;
+    const game = new VoxelmonGame(data, new RecorderHost(), 1);
+    game.newGame();
+    const mon = game.save.party[0]!;
+    mon.level = 16;
+    mon.species = "SQUIRTLE";
+    game.runEvolutions(new Set([mon]));
+    // the two pages queue as one box; drive it closed
+    for (let i = 0; i < 400 && mon.species === "SQUIRTLE"; i++) {
+      game.tick(i % 30 === 29 ? VOX_BTN.a : 0);
+    }
+    expect(mon.species).toBe("WARTORTLE");
+    // Evolution.lua:104 — the stats follow the new base stats
+    expect(mon.stats.hp).toBeGreaterThan(0);
+  });
+});

--- a/voxelmon/cook/gamedata.ts
+++ b/voxelmon/cook/gamedata.ts
@@ -4,10 +4,12 @@
 // §gamedata) plus an `atlas` object carrying the page-index maps the guest
 // needs: sprite sheet name -> page, species -> front-pic page, the player
 // back page and the emote page — and `mapPalette`, the per-map SGB palette
-// index the guest emits at map entry. CMAP maps each single-char charmap entry's
-// UTF-16 code point to its GB tile code (multi-char sequences like <PKMN>
-// skip v1); the UI page lays glyphs at their GB codes, so tile id == code.
+// index the guest emits at map entry. CMAP maps each charmap entry's UTF-16
+// code point to its GB tile code, multi-character sequences included at their
+// minted LIGATURE_BASE point; the UI page lays glyphs at their GB codes, so
+// tile id == code.
 
+import { LIGATURE_BASE } from "../game/ui/tiles.ts";
 import type { GenData, MapDef, TilesetDef } from "./data.ts";
 
 export interface AtlasIndex {
@@ -181,14 +183,25 @@ export function buildGamedata(gen: GenData, atlas: AtlasIndex, cookedMaps: strin
 }
 
 /**
- * CMAP pairs: UTF-16 code point of each single-char glyph -> its GB tile
- * code, strictly ascending, first entry wins on duplicates.
+ * CMAP pairs: UTF-16 code point of each glyph -> its GB tile code, strictly
+ * ascending, first entry wins on duplicates.
+ *
+ * A multi-character sequence (`'s`, `<PK>`) is ONE glyph on the GB but has no
+ * code point of its own, so it gets a minted one at LIGATURE_BASE + code —
+ * the guest's `toCells` emits that, which is what makes a uiText string one
+ * code point per cell.
  */
 export function buildCharmap(gen: GenData): [number, number][] {
   const seen = new Map<number, number>();
   for (const entry of gen.font.charmap) {
     if (typeof entry.seq !== "string" || entry.seq.length !== 1) continue;
     const cp = entry.seq.charCodeAt(0);
+    if (cp > 0xffff) continue;
+    if (!seen.has(cp)) seen.set(cp, entry.code);
+  }
+  for (const entry of gen.font.charmap) {
+    if (typeof entry.seq !== "string" || entry.seq.length === 1) continue;
+    const cp = LIGATURE_BASE + entry.code;
     if (cp > 0xffff) continue;
     if (!seen.has(cp)) seen.set(cp, entry.code);
   }

--- a/voxelmon/game/audio/music.ts
+++ b/voxelmon/game/audio/music.ts
@@ -101,6 +101,20 @@ export class AudioDirector {
     return true;
   }
 
+  /**
+   * Music.lua:383 playOnce — a jingle, played over the map theme's slot.
+   *
+   * DEVIATION: the Lua arms `pendingRestore` and :403 oneShotPlaying holds
+   * the caller until the jingle ends, at which point Music.update puts the
+   * map theme back. This surface has no end-of-song query — that would be a
+   * new op, i.e. a later rung — so the caller decides when to `restore()`.
+   */
+  playOnce(song: string): boolean {
+    if (!this.banks?.song(song)) return false;
+    this.play(song);
+    return this.current === song;
+  }
+
   /** Music.lua:407 restoreMap — back to the map theme after a battle. */
   restore(): void {
     this.current = null;

--- a/voxelmon/game/battle/battle.ts
+++ b/voxelmon/game/battle/battle.ts
@@ -36,6 +36,7 @@ import {
   MOVE_ANIM_PRE,
   TEXT_PRE_ADVANCE,
   TEXT_SCROLL_PAIR,
+  YES_NO_ANSWER,
   hpDrainClosingFrames,
   hpDrainStepFrames,
 } from "../rules/timing.ts";
@@ -146,11 +147,23 @@ export class WildBattle implements EffectBattle {
   /** Set once finish() ran; the shell pops the state and stages the return. */
   finished: BattleResult | null = null;
 
+  /**
+   * Audio cues queued AT THE REFERENCE'S OWN CALL SITES and drained once per
+   * tick by the shell's policy (game.ts driveAudio). The battle names them
+   * (`cry:<species>`, `music:victory`, `music:restore`); it never touches the
+   * surface. Watching battle state from outside got the cues right but their
+   * ORDER wrong — the cry fired before the silhouettes landed, the victory
+   * theme a text box late, the map theme ten ticks after teardown.
+   */
+  readonly audioCues: string[] = [];
+
   // presentation flags the ui reads (enter() windows, BattleState.lua:1459+)
   introBalls = true;
   showPlayerBack = true;
   sendingOut = false;
   blackedOut = false;
+  /** SE_HIDE_ENEMY_MON_PIC (:1174) — the ball chain takes the pic away. */
+  enemyHidden = false;
   lastBall: string | null = null;
 
   // queue pump state (updateQueue :1064)
@@ -175,6 +188,9 @@ export class WildBattle implements EffectBattle {
   private charTimer = 0;
   choiceOpen = false;
   choiceYes = true;
+  /** The answer given, held on screen (ChoiceBox.lua:34) before it lands. */
+  private choicePending: boolean | null = null;
+  private choiceHold = 0;
 
   // party / item menus (v1 internal phases in place of the Lua's ui stack)
   partyIndex = 0;
@@ -183,7 +199,7 @@ export class WildBattle implements EffectBattle {
   itemList: string[] = [];
 
   private participants = new Set<PartyMon>();
-  /** mons that leveled up (EvolveAfterBattle hook — unused v1, kept). */
+  /** mons that leveled up; game.ts runs Evolution.checkParty on the way out. */
   leveledUp = new Set<PartyMon>();
 
   /**
@@ -415,6 +431,12 @@ export class WildBattle implements EffectBattle {
         return true;
       }
       if (item.anim !== undefined || item.hitRow) {
+        // :1174-1177 — HIDEPIC/SHOWPIC are ENGINE state, not animation
+        // state: the assignment sits before the animation-player block, so
+        // it happens with animations off too. The ball chain hides the wild
+        // mon while the ball shakes and brings it back on a breakout.
+        if (item.anim === "HIDEPIC_ANIM") this.enemyHidden = true;
+        else if (item.anim === "SHOWPIC_ANIM") this.enemyHidden = false;
         // PlayMoveAnimation's Delay3 before the first animation frame
         // (:1158-1167); v1 has no subanimation player, so the row then
         // resolves at once — the Lua's own no-animPlayer fallback applies
@@ -472,17 +494,34 @@ export class WildBattle implements EffectBattle {
         return true;
       }
       if (item?.choice && this.choiceOpen) {
+        // ChoiceBox.lua:34-45: the answer is held on screen for
+        // YES_NO_ANSWER frames before control comes back — both branches of
+        // DisplayTwoOptionMenu pay it (engine/menus/text_box.asm:322,:333).
+        if (this.choicePending !== null) {
+          this.choiceHold -= 1;
+          if (this.choiceHold <= 0) {
+            const answer = this.choicePending;
+            const fn = item.choice;
+            this.choicePending = null;
+            this.choiceOpen = false;
+            this.current = null;
+            fn(answer);
+          }
+          return true;
+        }
         if (input.wasPressed("up") || input.wasPressed("down")) {
           this.choiceYes = !this.choiceYes;
-        }
-        let answer: boolean | null = null;
-        if (input.wasPressed("a")) answer = this.choiceYes;
-        else if (input.wasPressed("b")) answer = false; // ChoiceBox B = NO
-        if (answer !== null) {
-          const fn = item.choice;
-          this.choiceOpen = false;
-          this.current = null;
-          fn(answer);
+        } else if (input.wasPressed("a")) {
+          // HandleMenuInput_ (home/window.asm) beeps on A and B alike
+          this.audioCues.push("sfx:Press_AB");
+          this.choicePending = this.choiceYes;
+          this.choiceHold = YES_NO_ANSWER;
+        } else if (input.wasPressed("b")) {
+          this.audioCues.push("sfx:Press_AB");
+          // .choseSecondMenuItem snaps the cursor to NO for the hold
+          this.choiceYes = false;
+          this.choicePending = false;
+          this.choiceHold = YES_NO_ANSWER;
         }
         return true;
       }
@@ -533,8 +572,11 @@ export class WildBattle implements EffectBattle {
     // the slide has landed (:1465 introSlide + :1793-1802); the voxel v1
     // has no silhouettes, so the hold rides the queue instead.
     this.queue.push({ wait: BATTLE_SLIDE_IN_FRAMES });
-    // PlayCry before WildMonAppearedText (:1496-1510, #303) — audio is a
-    // later rung; the row order is kept without a row.
+    // PrintBeginningBattleText (:1496-1510, common_text.asm:10-19, #303): a
+    // wild battle calls PlayCry BEFORE the "appeared!" box, so the cry lands
+    // with the text — after the silhouettes have slid in, not on the frame
+    // the battle was pushed.
+    this.act(() => this.audioCues.push(`cry:${this.enemy.mon.species}`));
     this.say(`Wild ${this.enemy.name}\nappeared!`);
     // _InitBattleCommon clears the intro chrome the instant the intro text
     // is dismissed (:1534-1539, #317)
@@ -1065,7 +1107,12 @@ export class WildBattle implements EffectBattle {
       // staging layer hides the side's card off the `fainted` flag
     });
     this.insertNext({ wait: FAINT_SLIDE });
-    // wild victory music before EnemyMonFaintedText (:3673-3681) — audio out
+    if (!battler.isPlayer) {
+      // FaintEnemyPokemon .wild_win (:3673-3681, core.asm:792-795): the
+      // victory theme starts AS THE SLIDE LANDS, before EnemyMonFaintedText
+      // and the exp text — not after the box is dismissed.
+      this.actNext(() => this.audioCues.push("music:victory"));
+    }
     this.sayNext(`${displayName(battler)}\nfainted!`);
     if (battler.isPlayer) {
       this.act(() => this.playerMonFainted());
@@ -1424,6 +1471,9 @@ export class WildBattle implements EffectBattle {
       console.warn(`battle finished ${this.result} with no healthy party; forcing blackout`);
       this.result = "lose";
     }
+    // :4647 — leaving the battle brings the map theme back HERE, at teardown,
+    // not after the POST_BATTLE_RETURN hold the shell still owes
+    this.audioCues.push("music:restore");
     this.finished = this.result ?? "run";
   }
 

--- a/voxelmon/game/battle/effects.ts
+++ b/voxelmon/game/battle/effects.ts
@@ -176,23 +176,52 @@ export function inflictStatus(
 }
 
 // ---------------------------------------------------------------------------
-// The ported handler subset. Reachable moves (dist/voxelmon/gen movesets,
-// Route 1/2/22 wilds L2-5 + starters L2-8, listed in the battle port report):
+// The ported handler subset. The census is over the COOKED map set
+// (cook/cli.ts DEFAULT_MAPS): gen/encounters.json puts PIDGEY, RATTATA and
+// WEEDLE at L2-5 in the ROUTE_1 and ROUTE_2 grass, and the player's own line
+// reaches L20-ish by grinding there (evolutions included, since a level
+// evolution now lands — rules/evolution.ts).
 //   GUST/TACKLE/QUICK_ATTACK/HORN_ATTACK/SCRATCH/PECK -> NO_ADDITIONAL_EFFECT
 //   GROWL  -> ATTACK_DOWN1_EFFECT      TAIL_WHIP/LEER -> DEFENSE_DOWN1_EFFECT
 //   SAND_ATTACK -> ACCURACY_DOWN1_EFFECT
+//   STRING_SHOT (WEEDLE L1)  -> SPEED_DOWN1_EFFECT
+//   POISON_STING (WEEDLE L1) -> POISON_SIDE_EFFECT1
+//   HARDEN (KAKUNA/METAPOD L1) -> DEFENSE_UP1_EFFECT
+//   HYPER_FANG (RATTATA L14) -> FLINCH_SIDE_EFFECT1
+//   FURY_ATTACK (SPEAROW L?, BEEDRILL L?) -> TWO_TO_FIVE_ATTACKS_EFFECT
+//   FOCUS_ENERGY (BEEDRILL L16) -> FOCUS_ENERGY_EFFECT
 //   LEECH_SEED (BULBASAUR L7) -> LEECH_SEED_EFFECT
 //   BUBBLE (SQUIRTLE L8) -> SPEED_DOWN_SIDE_EFFECT
 //   EMBER (CHARMANDER L9, one level past the window but one level-up away)
 //          -> BURN_SIDE_EFFECT1
 //   STRUGGLE (the no-PP fallback) -> RECOIL_EFFECT
+// Reachable but still NOT registered, both needing plumbing this slice does
+// not have: TWINEEDLE_EFFECT (BEEDRILL L20 — MoveEffects.lua registers it in
+// both `full` and `secondary`, and the second hit's poison reroute wants the
+// per-hit seam) and SWITCH_AND_TELEPORT_EFFECT (PIDGEY L19 WHIRLWIND —
+// effects.asm:810 ends the wild battle, which is a battle-exit path).
 // Everything else: NOT REGISTERED — degrades via the reference's own
 // unknown-effect fallbacks (see module header).
 // ---------------------------------------------------------------------------
 
+function statUp(stat: StageStat, delta: number): EffectRecord["run"] {
+  // MoveEffects.lua:74-78 statUp — the USER's stage, and no MIST guard
+  return (ctx) => ctx.changeStage(ctx.user, stat, delta, false);
+}
+
 function statDown(stat: StageStat, delta: number): EffectRecord["run"] {
   // MoveEffects.lua:80-84 statDown
   return (ctx) => ctx.changeStage(ctx.target, stat, -delta, true);
+}
+
+function flinchSide(chance: number): EffectRecord["run"] {
+  // MoveEffects.lua:140-149 flinchSide — substitute blocks it, then
+  // rand(0..255) < chance; the flinch itself prints nothing
+  return (ctx) => {
+    if (ctx.target.substituteHP !== undefined) return [];
+    if (ctx.battle.rng.byte() < chance) ctx.target.flinched = true;
+    return [];
+  };
 }
 
 function statDownSide(stat: StageStat): EffectRecord["run"] {
@@ -230,6 +259,21 @@ export const EFFECTS: Record<string, EffectRecord> = {
   ATTACK_DOWN1_EFFECT: { kind: "primary", accuracyChecked: true, run: statDown("attack", 1) },
   DEFENSE_DOWN1_EFFECT: { kind: "primary", accuracyChecked: true, run: statDown("defense", 1) },
   ACCURACY_DOWN1_EFFECT: { kind: "primary", accuracyChecked: true, run: statDown("accuracy", 1) },
+  SPEED_DOWN1_EFFECT: { kind: "primary", accuracyChecked: true, run: statDown("speed", 1) },
+
+  // MoveEffects.lua:166-173 via statUp — the user's own stage, so no
+  // accuracy roll (ACC_CHECKED lists only the stat-DOWN moves)
+  DEFENSE_UP1_EFFECT: { kind: "primary", run: statUp("defense", 1) },
+
+  // MoveEffects.lua:235-239 — a second FOCUS ENERGY fails outright
+  FOCUS_ENERGY_EFFECT: {
+    kind: "primary",
+    run: (ctx) => {
+      if (ctx.user.focusEnergy) return ["But, it failed!"];
+      ctx.user.focusEnergy = true;
+      return [`${displayName(ctx.user)}'s\ngetting pumped!`];
+    },
+  },
 
   // MoveEffects.lua:189-199 — leech_seed.asm has no substitute check;
   // fails on an already-seeded or GRASS-type target
@@ -249,6 +293,22 @@ export const EFFECTS: Record<string, EffectRecord> = {
   // MoveEffects.lua:376 (statDownSide) / :365 (statusSide BRN 26)
   SPEED_DOWN_SIDE_EFFECT: { kind: "secondary", run: statDownSide("speed") },
   BURN_SIDE_EFFECT1: { kind: "secondary", run: statusSide("BRN", 26) },
+  // MoveEffects.lua:370 statusSide PSN 52 / :372 flinchSide 26
+  POISON_SIDE_EFFECT1: { kind: "secondary", run: statusSide("PSN", 52) },
+  FLINCH_SIDE_EFFECT1: { kind: "secondary", run: flinchSide(26) },
+
+  // MoveEffects.lua:482-486 — hitsFrom(:438) draws rand(0..len-1) over the
+  // 2/2/2/3/3/3/4/5 table when the move carries no multiHit of its own
+  TWO_TO_FIVE_ATTACKS_EFFECT: {
+    kind: "full",
+    hitCount: (ctx) => {
+      const dist = (ctx.move as MoveDef & { multiHit?: number | number[] }).multiHit ?? [
+        2, 2, 2, 3, 3, 3, 4, 5,
+      ];
+      if (typeof dist === "number") return dist;
+      return dist[randRange(ctx.rng, 0, dist.length - 1)]!;
+    },
+  },
 
   // MoveEffects.lua:530-539 RECOIL_EFFECT — recoil.asm reads the RAW
   // computed wDamage, div 2 for Struggle, div 4 otherwise

--- a/voxelmon/game/battle/staging.ts
+++ b/voxelmon/game/battle/staging.ts
@@ -85,7 +85,14 @@ export function desiredCards(
   const out: CardDesire[] = [];
   const [ex, ey] = staging.arena.enemyCell;
   const [px, py] = staging.arena.playerCell;
-  if (battle.enemy && !battle.enemy.fainted && battle.result !== "caught") {
+  // BattleState.lua:5283 — the draw gate reads enemyHidden too, so the ball
+  // chain's HIDEPIC row takes the wild mon off the field while it shakes
+  if (
+    battle.enemy &&
+    !battle.enemy.fainted &&
+    !battle.enemyHidden &&
+    battle.result !== "caught"
+  ) {
     const pic = picPageFor(data, battle.enemy.mon.species);
     if (pic >= 0) out.push({ side: 1, pic, x: ex, y: ey });
   }

--- a/voxelmon/game/battle/ui.ts
+++ b/voxelmon/game/battle/ui.ts
@@ -28,6 +28,7 @@ import {
   MAX_COLS,
   SPACE,
   encodeGlyphs,
+  toCells,
 } from "../ui/tiles.ts";
 import { HP_BAR_PIXELS, hpBarPixels } from "../rules/timing.ts";
 import type { WildBattle } from "./battle.ts";
@@ -89,6 +90,8 @@ const ARROW_Y = 16;
 interface MsgRowCache {
   text: string;
   revealed: number;
+  /** true once the row was stamped into the grid (it stopped being live). */
+  stamped: boolean;
 }
 
 export class BattleUi {
@@ -498,12 +501,24 @@ export class BattleUi {
     battle.shown.forEach((line, i) => {
       if (i >= MSG_ROWS.length) return;
       const isLast = i === battle.shown.length - 1;
-      const pad = Math.max(0, MAX_COLS - line.codes.length);
-      const text = isLast ? line.text : line.text + " ".repeat(pad);
       const cached = this.msgRows[i];
-      if (!cached || cached.text !== text) {
+      if (!isLast) {
+        // a finished row is chrome now: the core retains only the LAST
+        // uiText, so leaving it there would blank it the instant the next
+        // line begins (drawTextArea :5515 draws both rows every frame)
+        if (cached && cached.stamped && cached.text === line.text) return;
+        for (let c = 0; c < line.codes.length; c++) {
+          host.uiTile(MSG_X + c, MSG_ROWS[i], line.codes[c]!);
+        }
+        const pad = Math.max(0, MAX_COLS - line.codes.length);
+        if (pad > 0) host.uiFill(MSG_X + line.codes.length, MSG_ROWS[i], pad, 1, SPACE);
+        this.msgRows[i] = { text: line.text, revealed: -1, stamped: true };
+        return;
+      }
+      const text = toCells(line.text);
+      if (!cached || cached.stamped || cached.text !== text) {
         host.uiText(MSG_X, MSG_ROWS[i], text);
-        this.msgRows[i] = { text, revealed: -1 };
+        this.msgRows[i] = { text, revealed: -1, stamped: false };
         textsEmitted = true;
       }
     });

--- a/voxelmon/game/game.ts
+++ b/voxelmon/game/game.ts
@@ -12,7 +12,7 @@
 
 import { fromSection, type AudioBanks } from "./audio/banks.ts";
 import { AudioDirector } from "./audio/music.ts";
-import { WildBattle, type BattleResult } from "./battle/battle.ts";
+import { WildBattle } from "./battle/battle.ts";
 import { healMon, newMon, type PartyMon } from "./battle/mon.ts";
 import { computeStaging, type BattleStaging } from "./battle/staging.ts";
 import { BattleUi } from "./battle/ui.ts";
@@ -20,7 +20,9 @@ import type { VoxelmonData } from "./data.ts";
 import type { VoxelHost } from "./host.ts";
 import { Input } from "./input.ts";
 import { seededRng, type Rng } from "./rng.ts";
-import { POST_BATTLE_RETURN } from "./rules/timing.ts";
+import { apply as applyEvolution, checkParty } from "./rules/evolution.ts";
+import { movesLearnedAt } from "./rules/experience.ts";
+import { MAP_ENTRY_AFTER_BATTLE, POST_BATTLE_RETURN, YES_NO_ANSWER } from "./rules/timing.ts";
 import {
   Scene,
   type BattleSceneView,
@@ -100,27 +102,50 @@ class TextBoxState implements GameState, UiBoxSource {
 
 class ChoiceState implements GameState, ChoiceSource {
   readonly kind = "choice";
-  yes = true;
+  yes: boolean;
+  /** The answer given, held on screen before it is handed back. */
+  private pending: boolean | null = null;
+  private holdFrames = 0;
   constructor(
     private game: VoxelmonGame,
     private cb: (yes: boolean) => void,
-  ) {}
+    opts?: { defaultNo?: boolean; noSound?: boolean },
+  ) {
+    // ChoiceBox.lua:16 — some of the original's prompts open on NO
+    this.yes = !opts?.defaultNo;
+    this.noSound = opts?.noSound === true;
+  }
+  private readonly noSound: boolean;
   update(): void {
     const input = this.game.input;
+    // ChoiceBox.lua:34-45: BOTH branches of DisplayTwoOptionMenu hold 15
+    // frames with the menu still up before TwoOptionMenu_RestoreScreenTiles
+    // hands control back (engine/menus/text_box.asm:322-323, :333-334).
+    if (this.pending !== null) {
+      this.holdFrames -= 1;
+      if (this.holdFrames <= 0) {
+        const yes = this.pending;
+        this.pending = null;
+        this.game.pop(); // this choice
+        this.game.pop(); // the text box under it (ChoiceBox pops both)
+        this.cb(yes);
+      }
+      return;
+    }
     if (input.wasPressed("up") || input.wasPressed("down")) {
       this.yes = !this.yes;
-    }
-    if (input.wasPressed("a")) {
-      this.game.audio.playSfx("Press_AB"); // ChoiceBox.lua:53
-      this.game.pop(); // this choice
-      this.game.pop(); // the text box under it (ChoiceBox pops both)
-      this.cb(this.yes);
+    } else if (input.wasPressed("a")) {
+      // HandleMenuInput_ (home/window.asm): SFX_PRESS_AB on A and B alike
+      if (!this.noSound) this.game.audio.playSfx("Press_AB"); // ChoiceBox.lua:53
+      this.pending = this.yes;
+      this.holdFrames = YES_NO_ANSWER;
     } else if (input.wasPressed("b")) {
-      // B answers NO (pokered HandleYesNoMenu's B path)
-      this.game.audio.playSfx("Press_AB"); // ChoiceBox.lua:59
-      this.game.pop();
-      this.game.pop();
-      this.cb(false);
+      if (!this.noSound) this.game.audio.playSfx("Press_AB"); // ChoiceBox.lua:59
+      // .choseSecondMenuItem writes wCurrentMenuItem = 1 BEFORE the hold, so
+      // the cursor visibly snaps to NO for those 15 frames
+      this.yes = false;
+      this.pending = false;
+      this.holdFrames = YES_NO_ANSWER;
     }
   }
 }
@@ -156,7 +181,6 @@ class BattleGameState implements GameState, BattleSceneView {
   readonly battle: WildBattle;
   readonly staging: BattleStaging | null;
   readonly ui = new BattleUi();
-  private postFrames = -1;
 
   constructor(
     private game: VoxelmonGame,
@@ -174,15 +198,21 @@ class BattleGameState implements GameState, BattleSceneView {
   update(): void {
     const b = this.battle;
     if (b.finished) {
-      // POST_BATTLE_RETURN (home/overworld.asm:351-352): the hold before
-      // EnterMap hands the map back; then pop to the overworld exactly
-      // where the player stood
-      if (this.postFrames < 0) this.postFrames = POST_BATTLE_RETURN;
-      this.postFrames -= 1;
-      if (this.postFrames <= 0) {
-        this.game.pop();
-        if (b.finished === "lose") this.game.blackout();
-      }
+      // BattleState.lua:4647-4653 — teardown pops the battle screen FIRST,
+      // and it is the map that holds: POST_BATTLE_RETURN before EnterMap
+      // (home/overworld.asm:351-352) and then MapEntryAfterBattle's
+      // GBFadeInFromWhite (:22, :749-753). The port renders both as held
+      // frames, the convention WarpFadeState already uses for the warp fade.
+      this.game.pop();
+      // OverworldController.lua:3851-3894 afterBattle: the blackout warps to
+      // the heal point FIRST and takes evolutions() as its callback (:3882),
+      // every other exit runs them straight away (:3892).
+      if (b.finished === "lose") this.game.blackout();
+      this.game.pushWarpFade(
+        POST_BATTLE_RETURN + MAP_ENTRY_AFTER_BATTLE,
+        () => {},
+        () => this.game.runEvolutions(b.leveledUp),
+      );
       return;
     }
     b.update(this.game.input);
@@ -219,7 +249,7 @@ export class VoxelmonGame implements OverworldShell, SceneView {
   // themselves; the port watches the same state transitions from one place)
   private audioMap: string | null = null;
   private audioBattle = false;
-  private audioResult: BattleResult | null = null;
+  private audioRestored = false;
 
   constructor(data: VoxelmonData, host: VoxelHost, seed = 1) {
     this.data = data;
@@ -269,28 +299,51 @@ export class VoxelmonGame implements OverworldShell, SceneView {
     if (bv) {
       if (!this.audioBattle) {
         this.audioBattle = true;
-        this.audioResult = null;
+        // play_battle_music.asm runs before the transition (:1458); the cry
+        // and the victory theme are NOT observed from out here — the battle
+        // queues them where the reference does and we drain them below.
         this.audio.playBattle("wild");
-        this.audio.playCry(bv.battle.enemy.mon.species);
-      } else if (bv.battle.result && bv.battle.result !== this.audioResult) {
-        this.audioResult = bv.battle.result;
-        // Music.playVictory only has a jingle for a won fight; a run or a
-        // catch keeps the battle theme until the state pops.
-        if (bv.battle.result === "win") this.audio.playVictory("wild");
       }
+      this.drainBattleCues(bv.battle);
       return;
     }
     if (this.audioBattle) {
       this.audioBattle = false;
-      this.audioResult = null;
-      this.audio.restore();
+      // the battle's own finish() already queued music:restore; this is the
+      // backstop for a battle torn down without one
+      if (!this.audioRestored) this.audio.restore();
+      this.audioRestored = false;
       return;
     }
     const mapId = this.overworld.map.id;
-    if (mapId !== this.audioMap) {
+    // A connection crossing switches the map at the START of the seam step;
+    // its theme is owed to the frame the step LANDS (OverworldController.lua:
+    // 1075), and the overworld pays it through startMapMusic. Observing the
+    // map id here would jump the gun by a whole step.
+    if (mapId !== this.audioMap && !this.overworld.pendingSeamMusic) {
       this.audioMap = mapId;
       this.audio.startMap(mapId);
     }
+  }
+
+  /** Play what the battle queued, in the order it queued it. */
+  private drainBattleCues(battle: WildBattle): void {
+    const cues = battle.audioCues;
+    for (const cue of cues) {
+      if (cue.startsWith("cry:")) {
+        this.audio.playCry(cue.slice(4));
+      } else if (cue.startsWith("sfx:")) {
+        this.audio.playSfx(cue.slice(4));
+      } else if (cue === "music:victory") {
+        // Music.playVictory only has a jingle for a won fight
+        this.audio.playVictory("wild");
+      } else if (cue === "music:restore") {
+        this.audio.restore();
+        this.audioRestored = true;
+        this.audioMap = this.overworld.map.id;
+      }
+    }
+    cues.length = 0;
   }
 
   /**
@@ -304,7 +357,12 @@ export class VoxelmonGame implements OverworldShell, SceneView {
    */
   newGame(): void {
     this.save = {
-      flags: {},
+      // The starter is already in the party below, so the world must read
+      // as it does AFTER Oak's lab: every hand-ported script branches on
+      // this flag (data/scripts/reds_house.lua, pallet_town.lua), and with
+      // it clear Mom would offer the wake-up line to a trainer who already
+      // has a mon and Oak would still be barring the grass.
+      flags: { EVENT_GOT_STARTER: true },
       inventory: {},
       player: { name: "RED", rival: "BLUE" },
       lastHeal: { map: "PALLET_TOWN", x: 5, y: 6 },
@@ -385,6 +443,26 @@ export class VoxelmonGame implements OverworldShell, SceneView {
 
   // OverworldShell ------------------------------------------------------
 
+  /** Commands.lua:587 heal_party — Pokemon.lua:90 heal over the party. */
+  healParty(): void {
+    for (const mon of this.save.party) healMon(this.data, mon);
+  }
+
+  /** Music.lua:383 playOnce / :407 restoreMap, for the script verbs. */
+  playOnce(song: string): void {
+    this.audio.playOnce(song);
+  }
+
+  restoreMapMusic(): void {
+    this.audio.restore();
+  }
+
+  /** Music.lua:339 playMap, from the site that owns the moment. */
+  startMapMusic(mapId: string): void {
+    this.audioMap = mapId;
+    this.audio.startMap(mapId);
+  }
+
   showText(text: string, onDone?: () => void): void {
     this.push(new TextBoxState(this, text, onDone));
   }
@@ -395,6 +473,68 @@ export class VoxelmonGame implements OverworldShell, SceneView {
 
   pushWarpFade(frames: number, midpoint: () => void, onDone?: () => void): void {
     this.push(new WarpFadeState(this, frames, midpoint, onDone));
+  }
+
+  /**
+   * Evolution.lua:195-223 checkParty driving :156-178 evolve, one mon at a
+   * time in party order. The Lua plays EvolutionState's flashing-forms movie
+   * when it has graphics and falls back to the plain text flow otherwise;
+   * this slice takes the fallback — the same two pages, the same apply, and
+   * the evolved species' exact-level learn check afterwards (:174, the
+   * evos_moves.asm EvolveMon -> LearnMoveFromLevelUp predef).
+   */
+  runEvolutions(leveledUp: ReadonlySet<PartyMon> | null | undefined): void {
+    const pending = checkParty(this.data, this.save.party, leveledUp);
+    if (pending.length === 0) return;
+    const step = (i: number): void => {
+      const row = pending[i];
+      if (!row) return;
+      const { mon, to } = row;
+      const oldName = mon.nickname ?? this.data.pokemon[mon.species]!.name;
+      const newName = this.data.pokemon[to]!.name;
+      applyEvolution(this.data, mon, to);
+      this.showText(
+        `What?\n${oldName} is\nevolving!\fCongratulations!\nYour ${oldName}\nevolved into\n${newName}!`,
+        () => {
+          this.learnEvolutionMoves(mon, () => step(i + 1));
+        },
+      );
+    };
+    step(0);
+  }
+
+  /**
+   * Evolution.lua:112-152 learnEvolutionMoves — the EVOLVED species' learnset
+   * at exactly this level (movesLearnedAt, not movesAtLevel), each new move
+   * announced on its own page. A full moveset keeps battle.ts's v1 deviation:
+   * MoveLearnMenu is not in this slice, so the mon declines and says so.
+   */
+  private learnEvolutionMoves(mon: PartyMon, onDone: () => void): void {
+    const def = this.data.pokemon[mon.species]!;
+    const learned = movesLearnedAt(def, mon.level);
+    const name = mon.nickname ?? def.name;
+    const step = (i: number): void => {
+      const moveId = learned[i];
+      if (!moveId) {
+        onDone();
+        return;
+      }
+      const mdef = this.data.moves[moveId];
+      if (!mdef || mon.moves.some((mv) => mv.id === moveId)) {
+        step(i + 1);
+        return;
+      }
+      if (mon.moves.length < 4) {
+        mon.moves.push({ id: moveId, pp: mdef.pp });
+        this.showText(`${name} learned\n${mdef.name}!`, () => step(i + 1));
+        return;
+      }
+      this.showText(
+        `${name} is trying to\nlearn ${mdef.name}!\f${name} did not learn\n${mdef.name}!`,
+        () => step(i + 1),
+      );
+    };
+    step(0);
   }
 
   // OverworldShell keeps the seam's method name (overworld.ts is another

--- a/voxelmon/game/rules/evolution.ts
+++ b/voxelmon/game/rules/evolution.ts
@@ -4,11 +4,12 @@
 // evolutions on item use, trade evolutions when a link trade completes.
 //
 // Ported: METHODS, pendingFor, pendingLevelEvo, apply (the stat/HP-delta/dex
-// mutation). Not ported (UI/flow, per the check-logic-only scope): evolve,
-// learnEvolutionMoves, request, checkParty, the Runtime hooks and the
-// registry seam. The learn-on-evolve rule those flows call lives in
-// experience.ts movesLearnedAt (entry.level == level exactly — a mon
-// evolving at a learnset level gains that move, one level later does not).
+// mutation) and checkParty's QUEUE — the after-battle hook's decision, kept
+// pure so the caller owns the pages (game.ts runs them, since the Lua's
+// evolve() is a Screens push). Not ported: request, the Runtime hooks and the
+// registry seam. The learn-on-evolve rule lives in experience.ts
+// movesLearnedAt (entry.level == level exactly — a mon evolving at a learnset
+// level gains that move, one level later does not).
 
 import type { EvolutionEntry, SpeciesDef, VoxelmonData } from "../data.ts";
 import { calc, type DVs, type StatExp } from "./stats.ts";
@@ -91,6 +92,29 @@ export function pendingLevelEvo(data: VoxelmonData, mon: EvoMon): string | null 
 export interface Pokedex {
   seen: Record<string, boolean>;
   owned: Record<string, boolean>;
+}
+
+/**
+ * Evolution.lua:195-223 checkParty — the after-battle hook, decision half:
+ * party order, and ONLY mons that gained a level in the battle that just
+ * ended (Gen 1's EvolveAfterBattle; a mon that qualified earlier and did not
+ * level this time waits for its next level-up). The Lua queues these one at a
+ * time through the evolve movie; here the caller drives the pages, so this
+ * returns the queue and mutates nothing.
+ */
+export function checkParty<T extends EvoMon>(
+  data: VoxelmonData,
+  party: readonly T[],
+  leveledUp: ReadonlySet<T> | null | undefined,
+): { mon: T; to: string; evo: EvolutionEntry }[] {
+  const pending: { mon: T; to: string; evo: EvolutionEntry }[] = [];
+  if (!leveledUp) return pending;
+  for (const mon of party) {
+    if (!leveledUp.has(mon)) continue;
+    const hit = pendingFor(data, mon, { kind: "levelup" });
+    if (hit) pending.push({ mon, to: hit[0], evo: hit[1] });
+  }
+  return pending;
 }
 
 /**

--- a/voxelmon/game/rules/timing.ts
+++ b/voxelmon/game/rules/timing.ts
@@ -30,6 +30,11 @@ export const WARP_FADE_IN = 0;
 // home/overworld.asm:351-352 — after a battle, before EnterMap
 export const POST_BATTLE_RETURN = 10;
 
+// home/overworld.asm:22 + :749-753 — EnterMap sees BIT_BATTLE_OVER_OR_BLACKOUT
+// and runs MapEntryAfterBattle, which is GBFadeInFromWhite. Every battle
+// leaves through it (BattleState.lua:4652).
+export const MAP_ENTRY_AFTER_BATTLE = FADE_IN_FROM_WHITE;
+
 // engine/overworld/player_animations.asm:5-7 — EnterMapAnim, the fly /
 // teleport / dungeon-warp arrival: Delay3 then GBFadeInFromWhite
 export const SPECIAL_WARP_ENTRY = DELAY3 + FADE_IN_FROM_WHITE;

--- a/voxelmon/game/scene.ts
+++ b/voxelmon/game/scene.ts
@@ -38,6 +38,7 @@ import {
   MAX_COLS,
   SPACE,
   TEXT_X,
+  toCells,
 } from "./ui/tiles.ts";
 
 // gen1recomp src/render/SpriteRenderer.lua:85 — the walk-sheet frame order
@@ -410,9 +411,16 @@ export class Scene {
     }
   }
 
+  /** Static label into the retained grid, glyph by glyph (tile id == code). */
+  private stamp(host: VoxelHost, x: number, y: number, s: string): void {
+    const codes = encodeGlyphs(s);
+    for (let i = 0; i < codes.length; i++) host.uiTile(x + i, y, codes[i]!);
+  }
+
   // ui — the dialogue box as a retained tile-layer program: border once on
-  // open, uiText per line begin, uiReveal as the typewriter advances (the
-  // reveal counter applies to the LAST uiText — voxel-spec).
+  // open, uiText for the row that is typing, uiReveal as the typewriter
+  // advances (the reveal counter applies to the LAST uiText — voxel-spec),
+  // and every finished row stamped into the grid.
   private emitUi(view: SceneView): void {
     const host = this.host;
     const owner = view.uiBox();
@@ -453,28 +461,40 @@ export class Scene {
       this.uiRows = [];
       this.uiPage = box.pageIndex;
     }
-    // rows: shown[0] at LINE1_Y, shown[1] at LINE2_Y (TextBox.lua:370)
+    // rows: shown[0] at LINE1_Y, shown[1] at LINE2_Y. TextBox.lua:370 draws
+    // EVERY retained line every frame, but `uiText` is the ONE live
+    // typewriter run and the core keeps only the last (voxel-spec §ui), so a
+    // finished row has to be stamped into the retained tile grid or it
+    // disappears the moment the next line begins typing. Glyph codes ARE ui
+    // tile ids under the GB convention, so the stamp is the encode.
     for (let i = 0; i < box.shown.length; i++) {
       const line = box.shown[i]!;
       const isLast = i === box.shown.length - 1;
+      const y = i === 0 ? LINE1_Y : LINE2_Y;
       const cached = this.uiRows[i];
-      // Identity hit: same ShownLine in the same role builds the same text
-      // by construction, so the pad rebuild + glyph encode + full-string
-      // compare (once EVERY tick a box was open) all skip.
+      // Identity hit: same ShownLine in the same role emits the same ops by
+      // construction, so the encode + full-string compare (once EVERY tick a
+      // box was open) both skip.
       if (cached && cached.line === line && cached.wasLast === isLast) {
         continue;
       }
-      // Only non-last rows need the pad (a scroll must clear the glyphs
-      // beneath); the typing row skips the encode entirely.
-      const text = isLast
-        ? line.text
-        : line.text + " ".repeat(Math.max(0, MAX_COLS - encodeGlyphs(line.text).length));
+      if (!isLast) {
+        const codes = encodeGlyphs(line.text);
+        for (let c = 0; c < codes.length; c++) host.uiTile(TEXT_X + c, y, codes[c]!);
+        // a scroll must clear whatever the row above used to carry
+        if (codes.length < MAX_COLS) {
+          host.uiFill(TEXT_X + codes.length, y, MAX_COLS - codes.length, 1, SPACE);
+        }
+        this.uiRows[i] = { line, wasLast: isLast, text: line.text, revealed: -1 };
+        continue;
+      }
+      const text = toCells(line.text);
       if (!cached || cached.text !== text) {
-        host.uiText(TEXT_X, i === 0 ? LINE1_Y : LINE2_Y, text);
+        host.uiText(TEXT_X, y, text);
         this.uiRows[i] = { line, wasLast: isLast, text, revealed: -1 };
         textsEmitted = true;
       } else {
-        // Same text as the row already stamped (a scrolled-in twin): the op
+        // Same text as the row already typing (a scrolled-in twin): the op
         // stream stays silent exactly as before — only the identity re-pins.
         cached.line = line;
         cached.wasLast = isLast;
@@ -523,8 +543,11 @@ export class Scene {
         host.uiFill(cx + 1, cy + 4, 4, 1, BORDER_H);
         host.uiTile(cx + 5, cy + 4, BORDER_BR);
         host.uiFill(cx + 1, cy + 1, 4, 3, SPACE);
-        host.uiText(cx + 2, cy + 1, "YES");
-        host.uiText(cx + 2, cy + 3, "NO");
+        // static labels go into the grid, never through uiText (voxel-spec
+        // §ui): a uiText here would take the live run away from the dialogue
+        // row typing underneath it
+        this.stamp(host, cx + 2, cy + 1, "YES");
+        this.stamp(host, cx + 2, cy + 3, "NO");
         host.uiTile(cx + 1, choice.yes ? cy + 1 : cy + 3, ARROW_CURSOR);
       } else if (choice.yes !== this.choiceYes) {
         this.choiceYes = choice.yes;

--- a/voxelmon/game/ui/tiles.ts
+++ b/voxelmon/game/ui/tiles.ts
@@ -249,6 +249,49 @@ export function glyphLen(text: string): number {
 }
 
 /**
+ * Private-use base for the multi-character charmap sequences. `uiText`
+ * addresses the pak's CMAP by CODE POINT, so a glyph the GB spells with two
+ * source characters (`'s`, `<PK>`) has no code point of its own; the cook
+ * mints one here (LIGATURE_BASE + the glyph's GB code) and `toCells` emits
+ * it. Font.lua:262 matches those sequences greedily and Font.lua:358
+ * advanceOf gives each exactly one cell, so this is what keeps the guest's
+ * count and the surface's pen agreeing.
+ */
+export const LIGATURE_BASE = 0xe000;
+
+/**
+ * The cell-exact form of a line: one UTF-16 code unit per GB glyph cell.
+ *
+ * `uiText` is counted by the surface in code points (uiReveal caps them and
+ * the pen advances one cell each), while the guest counts GLYPHS — so a line
+ * carrying `'s` used to reveal one cell short of its end and pad one cell
+ * wide. Single-char glyphs stay their own character, which keeps recorded op
+ * traces readable; only the digraphs take a minted code point.
+ */
+export function toCells(text: string): string {
+  let out = "";
+  let i = 0;
+  outer: while (i < text.length) {
+    const bucket = MULTI_BY_HEAD.get(text[i]!);
+    if (bucket) {
+      for (const [seq, code] of bucket) {
+        if (text.startsWith(seq, i)) {
+          out += String.fromCharCode(LIGATURE_BASE + code);
+          i += seq.length;
+          continue outer;
+        }
+      }
+    }
+    const cp = String.fromCodePoint(text.codePointAt(i)!);
+    // an unmapped character is a SPACE to encodeGlyphs, so it must be one
+    // here too or the cell count would drift again
+    out += SINGLE.has(cp) ? cp : " ";
+    i += cp.length;
+  }
+  return out;
+}
+
+/**
  * Cut a string after `n` glyphs — the reveal boundary in source-string
  * space, used by tests to reason about uiReveal counts.
  */

--- a/voxelmon/game/world/map.ts
+++ b/voxelmon/game/world/map.ts
@@ -72,7 +72,17 @@ export function defCellTile(
   }
   const block = ts.blocks[id ?? 0];
   if (!block) return null;
-  return block[(ty % 4) * 4 + (tx % 4)];
+  return block[mod4(ty) * 4 + mod4(tx)];
+}
+
+/**
+ * Lua's `%` is FLOORED, JavaScript's is truncated: a border-extended read at a
+ * negative tile coordinate (`tileAt(-1, y)`) picks index 3 of the block row in
+ * the reference and index -1 here, which reads nothing. Every live caller
+ * checks inBounds first today, so this is the guard on the read itself.
+ */
+function mod4(n: number): number {
+  return ((n % 4) + 4) % 4;
 }
 
 /** Map.lua:83 defIsWalkableCell. */
@@ -180,7 +190,7 @@ export class GameMap {
     const bx = Math.floor(tx / 4);
     const by = Math.floor(ty / 4);
     const block = this.tileset.blocks[this.blockAt(bx, by)];
-    return block[(ty % 4) * 4 + (tx % 4)];
+    return block[mod4(ty) * 4 + mod4(tx)];
   }
 
   // Map.lua:211 cellTile — the collision tile of a cell: bottom-left 8x8

--- a/voxelmon/game/world/mapscripts.ts
+++ b/voxelmon/game/world/mapscripts.ts
@@ -1,0 +1,79 @@
+// The hand-ported map scripts, the registry half of gen1recomp
+// data/scripts/init.lua + src/script/MapScripts.lua: map-specific behavior
+// lives HERE, never in the world classes.
+//
+// Each entry is { talk: { TEXT_CONST: ScriptRow[] } } — the shape
+// MapScripts.attachBase takes and ScriptRunner executes. Every script cites
+// the upstream file it was transcribed from, which in turn cites the pokered
+// script it ports; text arguments are the extracted labels (`_Label`), never
+// prose typed in here, so nothing ROM-derived is committed (docs/VOXEL.md §1).
+//
+// Scope: the maps this build cooks (cook/cli.ts DEFAULT_MAPS). Two upstream
+// scripts for those maps are NOT here, both needing rungs docs/VOXEL.md §10
+// defers: data/scripts/oaks_lab.lua (the starter-choice cutscene — object
+// visibility, a forced walk, and the rival battle) and story2.lua's
+// PALLET_TOWN onStep (Oak stopping the player at the grass and walking them
+// to the lab, which this build's newGame has already happened — the starter
+// is in the party from the first frame, so the flag branches below resolve
+// the way upstream's do once that cutscene is over).
+
+import type { ScriptRow } from "./script.ts";
+
+export interface MapScript {
+  /** Keyed by the object's TEXT_* constant, the way MapScripts.talk does. */
+  talk?: Record<string, ScriptRow[]>;
+}
+
+export const MAP_SCRIPTS: Record<string, MapScript> = {
+  // data/scripts/reds_house.lua (pokered scripts/RedsHouse1F.asm). Mom:
+  // pre-starter shows the wake-up / Oak tip; after EVENT_GOT_STARTER,
+  // RedsHouse1FMomHealScript fades to white, heals, plays MUSIC_PKMN_HEALED,
+  // fades back, then "looking great".
+  REDS_HOUSE_1F: {
+    talk: {
+      TEXT_REDSHOUSE1F_MOM: [
+        ["face_player"], //                                        1
+        ["check_flag", "EVENT_GOT_STARTER"], //                     2
+        ["jump_if_true", 6], //                                     3
+        ["show_text", "_RedsHouse1FMomWakeUpText"], //              4
+        ["jump", "end"], //                                         5
+        // RedsHouse1FMomHealScript
+        ["show_text", "_RedsHouse1FMomYouShouldRestText"], //       6
+        ["fade", "out", "white"], //                                7  GBFadeOutToWhite
+        ["heal_party"], //                                          8
+        ["play_once", "Music_PkmnHealed"], //                       9
+        ["fade", "in", "white"], //                                10  GBFadeInFromWhite
+        ["show_text", "_RedsHouse1FMomLookingGreatText"], //       11
+      ],
+    },
+  },
+
+  // data/scripts/pallet_town.lua (pokered scripts/PalletTown.asm).
+  // PalletTownOakText is a text_asm branch on wOakWalkedToPlayer showing
+  // either _PalletTownOakHeyWaitDontGoOutText or _PalletTownOakItsUnsafeText;
+  // upstream branches on the starter flag, which tracks it. The champion
+  // rematch rows (upstream 2-19) need a trainer battle and are left out with
+  // the rest of §10's trainer rung — the branch that survives is the one v1
+  // content can reach.
+  PALLET_TOWN: {
+    talk: {
+      TEXT_PALLETTOWN_OAK: [
+        ["face_player"], //                                         1
+        ["check_flag", "EVENT_GOT_STARTER"], //                      2
+        ["jump_if_true", 6], //                                      3
+        ["show_text", "_PalletTownOakHeyWaitDontGoOutText"], //      4
+        ["jump", "end"], //                                          5
+        ["show_text", "_PalletTownOakItsUnsafeText"], //             6
+      ],
+    },
+  },
+};
+
+/**
+ * MapScripts.lua:239 talkScript — the script for an object's TEXT_* constant
+ * on a map, or null when nothing is registered and the plain extracted text
+ * is what the player should see.
+ */
+export function talkScript(mapLabel: string, textConst: string): ScriptRow[] | null {
+  return MAP_SCRIPTS[mapLabel]?.talk?.[textConst] ?? null;
+}

--- a/voxelmon/game/world/overworld.ts
+++ b/voxelmon/game/world/overworld.ts
@@ -19,6 +19,7 @@ import { canMove, occupied, target, type Dir, type Mover, type TilePairs } from 
 import { defPassable, GameMap, isOutside } from "./map.ts";
 import { NPC } from "./npc.ts";
 import { Player } from "./player.ts";
+import { talkScript } from "./mapscripts.ts";
 import { ScriptRunner, type ScriptWorld } from "./script.ts";
 import {
   destination,
@@ -59,6 +60,15 @@ export interface OverworldShell {
   rng: Rng;
   /** NPC wander stream, separate so ambience can't perturb encounters. */
   npcRng: Rng;
+  /** Sound.lua:190 play — the field cues the overworld itself triggers. */
+  audio: { playSfx(name: string): void };
+  /** Pokemon.lua:90 heal over the party (Commands.lua:587 heal_party). */
+  healParty(): void;
+  /** Music.lua:383 playOnce — a jingle; Music.lua:407 restoreMap after it. */
+  playOnce(song: string): void;
+  restoreMapMusic(): void;
+  /** Music.lua:339 playMap, called where the reference calls it. */
+  startMapMusic(mapId: string): void;
   showText(text: string, onDone?: () => void): void;
   showChoice(text: string, choice: (yes: boolean) => void): void;
   pushWarpFade(frames: number, midpoint: () => void, onDone?: () => void): void;
@@ -157,6 +167,12 @@ export class Overworld implements ScriptWorld {
   warpEntryCell?: { x: number; y: number };
   transitioning = false;
   private doorWarp = false;
+  /** OverworldController.lua:1221 — 16 ticks between wall-bonk cues. */
+  private bumpCooldown = 0;
+  /** A play_once jingle is in flight (Music.lua:389 pendingRestore). */
+  private oneShotPending = false;
+  /** OverworldController.lua:1455 — the map whose theme the seam step owes. */
+  pendingSeamMusic: string | null = null;
   private joyLatch?: { a?: boolean };
   private npcPool = new Map<string, NPC>();
   readonly tilePairs: TilePairs;
@@ -206,6 +222,10 @@ export class Overworld implements ScriptWorld {
   ): void {
     const def = this.shell.data.maps?.[mapId];
     if (!def) throw new Error(`unknown map ${mapId}`);
+    // crossConnection re-arms this right after; clearing here is what keeps a
+    // warp or a reload from leaving a stale deferred PlayMapMusic pending
+    // (OverworldController.lua:437-439).
+    this.pendingSeamMusic = null;
     const tileset = this.shell.data.tilesets?.[def.tileset];
     if (!tileset) throw new Error(`unknown tileset ${def.tileset} for ${mapId}`);
     this.map = new GameMap(def, tileset);
@@ -259,6 +279,7 @@ export class Overworld implements ScriptWorld {
 
   // OverworldController.lua:883 update
   update(): void {
+    if (this.bumpCooldown > 0) this.bumpCooldown -= 1;
     this.runner.update();
     // the emotion-bubble pause holds the world for a beat
     // (OverworldController.lua:1018); only the player animates through it
@@ -290,6 +311,14 @@ export class Overworld implements ScriptWorld {
     const entry = this.warpEntryCell;
     if (entry && (this.player.cellX !== entry.x || this.player.cellY !== entry.y)) {
       this.warpEntryCell = undefined;
+    }
+    // OverworldController.lua:1075 — the seam step landed, so the deferred
+    // PlayMapMusic runs now (and only if we are still on the map it was
+    // armed for; a warp taken mid-step drops it).
+    if (stepped && this.pendingSeamMusic) {
+      const pending = this.pendingSeamMusic;
+      this.pendingSeamMusic = null;
+      if (pending === this.map.id) this.shell.startMapMusic(pending);
     }
     if (stepped && !scripted) {
       this.onStepComplete();
@@ -367,7 +396,12 @@ export class Overworld implements ScriptWorld {
         if (w && this.map.isWarpTileCell(tx, ty) && !this.isCooked(w.def.destMap)) {
           this.player.facing = dir;
           this.player.bumpFrames = this.player.stepFrames;
-          continue;
+          // ENDS the poll, like every other outcome here (:1224 returns the
+          // tryMove result): a poll handles ONE held direction, so a held
+          // diagonal must not walk on the other axis, and falling through to
+          // the turn re-arm below would hand back a turn window the original
+          // never grants while a direction is down.
+          return;
         }
       }
       const result = this.player.tryMove(dir, this.map, this.entities, this.tilePairs);
@@ -378,7 +412,19 @@ export class Overworld implements ScriptWorld {
         const w = onCollision(this.map, this.carpets, this.player.cellX, this.player.cellY, dir);
         if (w) {
           this.takeWarp(w.def);
+          return;
         }
+      }
+      // OverworldController.lua:1218-1223: the bonk. Bumping another entity
+      // is silent, and the 16-frame cooldown is what keeps a held direction
+      // into a wall from machine-gunning the cue.
+      if (
+        result === "blocked" &&
+        this.player.lastBlockReason !== "entity" &&
+        this.bumpCooldown <= 0
+      ) {
+        this.shell.audio.playSfx("Collision");
+        this.bumpCooldown = 16;
       }
       return;
     }
@@ -416,12 +462,14 @@ export class Overworld implements ScriptWorld {
           if (!landing) return false;
           const { dest, ts, x, y } = landing;
           if (!defPassable(dest, ts, x, y, p.surfing)) return false;
+          this.shell.audio.playSfx("Ledge"); // OverworldController.lua:1352
           p.hopFrames = 32;
           p.hopTotal = 32;
           this.scriptMove(p, dir, 1, () => this.checkEdgeExit(dir));
           return true;
         }
         if (!occupied(this.entities, lx, ly, p) && this.map.isWalkableCell(lx, ly)) {
+          this.shell.audio.playSfx("Ledge"); // OverworldController.lua:1359
           p.hopFrames = 32; // jump arc (cosmetic; entities can't collide mid-hop
           p.hopTotal = 32; // because the hop is a scripted move that owns input)
           this.scriptMove(p, dir, 2);
@@ -521,6 +569,10 @@ export class Overworld implements ScriptWorld {
     // fresh walk-cycle clock so the seam step always shows leg frames
     p.animClock = 0;
     p.stepFramesCur = p.stepFrames;
+    // OverworldController.lua:1455 — the new map's theme is DEFERRED to the
+    // frame the seam step lands (issue #93). Starting it here would swap the
+    // song while the player is still visibly on the old map's last cell.
+    this.pendingSeamMusic = dest.id;
     // FixedStep:discardCatchup (OverworldController.lua:1477) is a no-op
     // here: the voxel host runs exactly one tick per frame, so there is no
     // catch-up accumulator to discard.
@@ -552,10 +604,9 @@ export class Overworld implements ScriptWorld {
     }
   }
 
-  // OverworldController.lua:2520 talkTo — the slice keeps the plain-text
-  // path: freeze, face the player, resolve the object's TEXT_* constant.
-  // Item balls, static encounters, trainer engagement and TX_SCRIPT marts/
-  // nurses are the battle/menu ports' seams.
+  // OverworldController.lua:2520 talkTo — freeze, then dispatch the object's
+  // TEXT_* constant. Item balls, static encounters, trainer engagement and
+  // TX_SCRIPT marts/nurses are the battle/menu ports' seams.
   talkTo(npc: NPC): void {
     npc.frozen = true;
     const unfreeze = () => {
@@ -564,9 +615,31 @@ export class Overworld implements ScriptWorld {
     this.showMapText(npc.def.text, npc, unfreeze);
   }
 
-  // OverworldController.lua:3241 showMapText — dispatch a TEXT_* constant
-  // through extracted text (hand-ported scripts are outside the slice).
+  // OverworldController.lua:3241 showMapText — a TEXT_* constant goes to the
+  // map's hand-ported script if it has one (MapScripts.lua:239 talkScript),
+  // and to the plain extracted line otherwise. The scripted path is what
+  // makes a text_asm branch branch: the extracted text of one of those
+  // pointers is only ever its FIRST case, so without the script Mom reads the
+  // wake-up line forever and Oak never stops warning you about the grass.
   showMapText(textConst: string, npc?: NPC, onDone?: () => void): void {
+    const script = talkScript(this.map.id, textConst);
+    if (script && !this.runner.isRunning()) {
+      if (npc) npc.frozen = true;
+      this.runner.run(script, {
+        npc,
+        onDone: () => {
+          if (this.oneShotPending) {
+            // Music.lua:403 oneShotPlaying holds the script until the jingle
+            // ends and Music.update restores the theme; this surface cannot
+            // ask, so the theme comes back when the script does.
+            this.oneShotPending = false;
+            this.shell.restoreMapMusic();
+          }
+          onDone?.();
+        },
+      });
+      return;
+    }
     const text = this.resolveText(textConst);
     if (text !== null) {
       if (npc) npc.facePlayer(this.player);
@@ -574,6 +647,34 @@ export class Overworld implements ScriptWorld {
     } else {
       onDone?.();
     }
+  }
+
+  // ScriptWorld (script.ts) — the services a command reaches -------------
+
+  /** Commands.lua:587 heal_party. */
+  healParty(): void {
+    this.shell.healParty();
+  }
+
+  /** Commands.lua:533 play_once — see showMapText's restore note. */
+  playOnce(songId: string, onDone: () => void): void {
+    this.oneShotPending = true;
+    this.shell.playOnce(songId);
+    onDone();
+  }
+
+  /**
+   * Commands.lua:1216 fade — the overlay ramps to the colour and back. The
+   * voxel surface has no overlay op, so the port spends the ramp's frames the
+   * way it spends every other fade's (game.ts WarpFadeState holds the world).
+   */
+  fade(_dir: "in" | "out", frames: number, onDone: () => void): void {
+    this.shell.pushWarpFade(frames, () => {}, onDone);
+  }
+
+  /** Commands.lua:162 face_player. */
+  facePlayer(npc: NPC): void {
+    npc.facePlayer(this.player);
   }
 
   // src/core/Data.lua:304 resolveText — map label + TEXT_* const through
@@ -697,7 +798,13 @@ export class Overworld implements ScriptWorld {
   startWarpTo(mapId: string, x: number, y: number, facing?: Dir, onDone?: () => void): void {
     if (!this.isCooked(mapId)) {
       // The door is locked: a warp into a map the pak has no geometry for
-      // would land the player in an invisible world.
+      // would land the player in an invisible world. The warp never happens,
+      // so nothing it staged may survive it — a doorWarp left armed here
+      // would spend itself on the NEXT warp, walking the player out of a
+      // door they did not enter — and a parked script must be resumed or the
+      // runner never wakes (ScriptRunner.lua:197 resume).
+      this.doorWarp = false;
+      onDone?.();
       return;
     }
     // ANY transition off an outdoor map remembers the outdoor side, so
@@ -718,6 +825,12 @@ export class Overworld implements ScriptWorld {
         // touched here: the flag the departing tile set rides through the
         // warp (issue #378).
         this.warpEntryCell = { x, y };
+        if (doorWarp) {
+          // OverworldController.lua:4053: the cue is chosen by where you
+          // LANDED, and it plays for every door warp — the door-tile test
+          // below only gates the walk-out step.
+          this.shell.audio.playSfx(isOutside(this.map.def) ? "Go_Outside" : "Go_Inside");
+        }
         if (doorWarp && this.map.isDoorTileCell(this.player.cellX, this.player.cellY)) {
           // PlayerStepOutFromDoor: any warp landing on a door tile
           // auto-steps south once. The walk-out is a simulated d-pad press,

--- a/voxelmon/game/world/script.ts
+++ b/voxelmon/game/world/script.ts
@@ -5,11 +5,19 @@
 // :233 update).
 //
 // Only the slice's verb set is ported from src/script/Commands.lua:
-// show_text :81, ask :154, set_flag :168, give_item :220, warp :308,
-// wait :316, move_player :330, emote :1014.
+// show_text :81, jump :143, ask :154, face_player :162, set_flag :168,
+// check_flag :176, jump_if_true :205, jump_if_false :209, give_item :220,
+// warp :308, wait :316, move_player :330, label :1005, emote :1014,
+// play_once :533, heal_party :587, fade :1216.
+//
+// The set is exactly what the cooked maps' hand-ported scripts invoke
+// (mapscripts.ts): everything upstream reaches for outside those scripts —
+// object visibility, forced-walk cutscenes, trainer engagement, the naming
+// screen, the dex rating — belongs to the rungs docs/VOXEL.md §10 defers.
 
 import type { VoxelmonData } from "../data.ts";
 import * as Bag from "../rules/bag.ts";
+import { FADE_OUT_TO_WHITE } from "../rules/timing.ts";
 import type { Dir } from "./collision.ts";
 import type { NPC } from "./npc.ts";
 
@@ -36,6 +44,14 @@ export interface ScriptWorld {
   scriptMove(entity: { moving: boolean }, dir: Dir, tiles: number, onDone?: () => void): void;
   player: { moving: boolean };
   setEmote(entity: unknown, bubble: number, frames: number, onDone: () => void): void;
+  /** Pokemon.lua:90 heal, over the whole party. */
+  healParty(): void;
+  /** Music.lua:playOnce — a one-shot song; onDone fires when it ends. */
+  playOnce(songId: string, onDone: () => void): void;
+  /** The fade overlay's ramp (Commands.lua:1216); the port holds frames. */
+  fade(dir: "in" | "out", frames: number, onDone: () => void): void;
+  /** Turn an NPC to face the player (NPC.lua facePlayer). */
+  facePlayer(npc: NPC): void;
 }
 
 export interface ScriptContext {
@@ -52,36 +68,49 @@ const EMOTE_BUBBLES: Record<string, number> = { shock: 1, question: 2, happy: 3 
 
 type Verb = (ctx: ScriptContext, ...args: unknown[]) => Generator<void, string | number | void>;
 
-// Commands.lua:70 show_text — textId is looked up in generated text (by
-// label or via the map's TEXT_* pointers), literal-string fallback for
-// hand-written rows. subs replaces dynamic {TOKEN}s.
-function* show_text(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
-  const textId = args[0] as string;
-  const subs = args[1] as Record<string, string> | undefined;
-  const w = ctx.world;
-  let text = (w.data.text as Record<string, string> | undefined)?.[textId]
-    ?? w.resolveText(textId)
-    ?? textId;
+// Commands.lua:70 show_text's lookup: a text label first, then the map's
+// TEXT_* pointers, and a hand-written row's literal string last. subs
+// replaces the dynamic {TOKEN}s the extracted line carries.
+function scriptText(
+  w: ScriptWorld,
+  textId: string,
+  subs?: Record<string, string>,
+): string {
+  let text =
+    (w.data.text as Record<string, string> | undefined)?.[textId] ??
+    w.resolveText(textId) ??
+    textId;
   if (subs) {
     for (const [token, value] of Object.entries(subs)) {
       text = text.replace(new RegExp(`\\{${token}:?\\w*\\}`, "g"), value);
     }
   }
+  return text;
+}
+
+// Commands.lua:70 show_text
+function* show_text(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
   const runner = ctx.runner;
-  w.showText(text, () => runner.resume());
+  const text = scriptText(
+    ctx.world,
+    args[0] as string,
+    args[1] as Record<string, string> | undefined,
+  );
+  ctx.world.showText(text, () => runner.resume());
   yield;
 }
 
-// Commands.lua:154 ask — show text, then a YES/NO box over the still-visible
-// text; result lands in ctx.lastCheck.
+// Commands.lua:154 ask — show_text with opts.choice, so the YES/NO box pops
+// over the still-visible text; the answer lands in ctx.lastCheck. It goes
+// through show_text, so it takes the same subs.
 function* ask(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
-  const textId = args[0] as string;
-  const w = ctx.world;
-  const text = (w.data.text as Record<string, string> | undefined)?.[textId]
-    ?? w.resolveText(textId)
-    ?? textId;
   const runner = ctx.runner;
-  w.showChoice(text, (yes) => {
+  const text = scriptText(
+    ctx.world,
+    args[0] as string,
+    args[1] as Record<string, string> | undefined,
+  );
+  ctx.world.showChoice(text, (yes) => {
     ctx.lastCheck = yes;
     runner.resume();
   });
@@ -112,9 +141,14 @@ function* give_item(ctx: ScriptContext, ...args: unknown[]): Generator<void, num
   const def = w.data.items?.[itemId];
   const name = def?.name ?? itemId;
   if (gotText !== false) {
-    w.showText((gotText as string | undefined) ?? `{PLAYER} got\n${name}!`, () =>
-      runner.resume(),
-    );
+    // gotText picks the script's own received-text (a label or a literal);
+    // pokered copies the item name into wStringBuffer first, so the extracted
+    // line's {RAM:wStringBuffer} slot is where the name goes.
+    const text =
+      gotText === undefined
+        ? `{PLAYER} got\n${name}!`
+        : scriptText(w, gotText as string, { "RAM:wStringBuffer": name });
+    w.showText(text, () => runner.resume());
     yield;
   }
 }
@@ -163,21 +197,106 @@ function* emote(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
   yield;
 }
 
+// Commands.lua:143 jump — the runner resolves a number to a row and a string
+// to a label ("end" halts).
+function* jump(_ctx: ScriptContext, ...args: unknown[]): Generator<void, string | number> {
+  return args[0] as string | number;
+}
+
+// Commands.lua:162 face_player
+function* face_player(ctx: ScriptContext): Generator<void, void> {
+  if (ctx.npc) ctx.world.facePlayer(ctx.npc);
+}
+
+// Commands.lua:176 check_flag (Flags.get: absent reads false)
+function* check_flag(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
+  ctx.lastCheck = ctx.world.save.flags[args[0] as string] === true;
+}
+
+// Commands.lua:205 jump_if_true / :209 jump_if_false — no jump when the test
+// fails, so the runner falls through to the next row.
+function* jump_if_true(
+  ctx: ScriptContext,
+  ...args: unknown[]
+): Generator<void, string | number | void> {
+  if (ctx.lastCheck) return args[0] as string | number;
+}
+
+function* jump_if_false(
+  ctx: ScriptContext,
+  ...args: unknown[]
+): Generator<void, string | number | void> {
+  if (!ctx.lastCheck) return args[0] as string | number;
+}
+
+// Commands.lua:1005 label — a jump target, and nothing at runtime.
+function* label(): Generator<void, void> {}
+
+// Commands.lua:587 heal_party (Pokemon.heal: full HP, status cleared, PP
+// restored) — the POKéMON CENTER heal Mom performs at home.
+function* heal_party(ctx: ScriptContext): Generator<void, void> {
+  ctx.world.healParty();
+}
+
+// Commands.lua:533 play_once — a one-shot song that BLOCKS until it ends
+// (runner.waitingCheck on Music.oneShotPlaying).
+function* play_once(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
+  const runner = ctx.runner;
+  ctx.world.playOnce(args[0] as string, () => runner.resume());
+  yield;
+}
+
+// Commands.lua:1216 fade — the overlay ramp, out to the colour then back in.
+// The voxel slice has no overlay op, so the ramp is the held frames the port
+// spends on every other fade (game.ts WarpFadeState); the colour argument is
+// carried for the citation and ignored.
+function* fade(ctx: ScriptContext, ...args: unknown[]): Generator<void, void> {
+  const dir = args[0] === "in" ? "in" : "out";
+  // parseFadeArgs (Commands.lua:1200): either order, the number is frames
+  const frames =
+    (typeof args[1] === "number" ? args[1] : typeof args[2] === "number" ? args[2] : undefined) ??
+    FADE_OUT_TO_WHITE;
+  const runner = ctx.runner;
+  ctx.world.fade(dir, frames, () => runner.resume());
+  yield;
+}
+
 const VERBS: Record<string, Verb> = {
   show_text,
   ask,
+  jump,
+  jump_if_true,
+  jump_if_false,
+  label,
+  face_player,
+  check_flag,
   set_flag,
   give_item,
   warp,
   wait,
   move_player,
+  heal_party,
+  play_once,
+  fade,
   emote,
 };
+
+/** ScriptRunner.lua:26 scanLabels — first row wins, 1-based like the Lua. */
+function scanLabels(script: ScriptRow[]): Map<string, number> {
+  const labels = new Map<string, number>();
+  script.forEach((row, i) => {
+    if (row[0] === "label" && typeof row[1] === "string" && !labels.has(row[1])) {
+      labels.set(row[1], i + 1);
+    }
+  });
+  return labels;
+}
 
 export class ScriptRunner {
   private co: Generator<void, void> | null = null;
   waitingFrames: number | null = null;
   ctx: ScriptContext | null = null;
+  private resuming = false;
   private world: ScriptWorld;
 
   constructor(world: ScriptWorld) {
@@ -198,22 +317,31 @@ export class ScriptRunner {
     this.resume();
   }
 
-  // ScriptRunner.lua:143 exec — a command list with jump targets returned
-  // as row numbers (1-based like the Lua) or Infinity for halt.
+  // ScriptRunner.lua:143 exec — a command list whose verbs return a jump
+  // target: a row number (1-based like the Lua), a label name, "end" to halt,
+  // or nothing to fall through.
   private *exec(script: ScriptRow[], ctx: ScriptContext): Generator<void, void> {
+    const labels = scanLabels(script);
     let pc = 1;
     while (pc <= script.length) {
       const row = script[pc - 1];
       const name = row[0];
       const fn = VERBS[name];
       if (!fn) {
-        // v1 skip: old content degrades instead of dying (ScriptRunner.lua:157)
+        // v1 skip: old content degrades instead of dying, but never in
+        // silence — ScriptRunner.lua:158 logs the row it dropped.
+        console.warn(`script: unknown command '${name}' (skipped)`);
         pc += 1;
         continue;
       }
       const jump = yield* fn(ctx, ...row.slice(1));
       if (typeof jump === "number") {
         pc = jump;
+      } else if (typeof jump === "string") {
+        if (jump === "end") break;
+        const target = labels.get(jump);
+        if (target === undefined) throw new Error(`jump to missing label '${jump}' at row ${pc}`);
+        pc = target;
       } else {
         pc += 1;
       }
@@ -227,7 +355,22 @@ export class ScriptRunner {
   resume(): void {
     const co = this.co;
     if (!co) return;
-    const r = co.next();
+    // ScriptRunner.lua:199-207: a completion callback can fire SYNCHRONOUSLY
+    // from inside the running generator (a text box that closes on the tick
+    // it opened, a warp whose destination is locked). Re-entering it would
+    // throw and kill the script, so land the pending yield and continue on
+    // the next update tick instead.
+    if (this.resuming) {
+      this.waitingFrames = 1;
+      return;
+    }
+    this.resuming = true;
+    let r: IteratorResult<void, void>;
+    try {
+      r = co.next();
+    } finally {
+      this.resuming = false;
+    }
     if (r.done) {
       if (this.co === co) {
         this.co = null;


### PR DESCRIPTION
A subsystem-by-subsystem re-read of the TypeScript port against the
[gen1recomp](https://github.com/bryanthaboi/gen1recomp) Lua upstream at HEAD
`f0ed2ef`, with every claimed divergence re-checked at its cited lines on both
sides before anything was changed.

**The rules modules came through clean.** Damage, crit, accuracy, the type
chart, catching, exp, growth, collision, ledges and connections are the Lua's
arithmetic verbatim — the audit could not move them. Everything it did find was
in the glue: a surface contract used the wrong way, registry entries never made,
and cues fired from the wrong moment.

## Fixed

| | |
|---|---|
| **Two-line pages showed one line** | `uiText` is THE one live typewriter run and the core retains only the last (spec §ui). The guest emitted one per row, so the first line went blank the instant the second began typing — nearly every sign, NPC line and battle message in the shipped maps. Finished rows are stamped into the retained grid now (glyph codes *are* ui tile ids); only the typing row is a `uiText`. |
| **Ligatures ate the last cell** | `'s` is one glyph to the guest (greedy digraph matching) and two characters to the surface, so a reveal stopped one cell short: `Can't escape!` printed as `Can't escape`. The cook mints a code point per multi-character charmap entry and `toCells` emits it. |
| **Two reachable move effects unregistered** | A Route 2 WEEDLE's STRING SHOT printed `But, it failed!` every time; its POISON STING could never poison. The reachable census was re-derived from the cooked map set rather than patched — four more effects registered with them. |
| **Evolution never fired** | `battle.leveledUp` was written and never read, so a SQUIRTLE that reached 16 on Route 1 stayed a SQUIRTLE forever. |
| **The script runner had no caller** | A `text_asm` pointer extracts only its FIRST branch, so Mom offered the wake-up line to a trainer who already had a starter and Oak never stopped barring the grass. The hand-ported map scripts for the cooked maps are in, and the verb set grew to what they invoke. |
| **Audio fired from the wrong moments** | Cues are queued at the reference's own call sites and drained by the shell — the cry no longer precedes the silhouettes, the victory theme is no longer a box late, the map theme no longer ten ticks late. The absent field cues are in: `Collision` (with its 16-frame cooldown), `Ledge`, `Go_Inside`/`Go_Outside`, and the seam-crossing theme deferred to the frame the step lands. |
| **The post-battle hand-back** | The battle screen is torn down first; the map pays `POST_BATTLE_RETURN` and then `MapEntryAfterBattle`'s 24 frames. |
| **YES/NO answers** | Hold 15 frames with the menu up, B snapping the cursor to NO. |
| **Smaller** | The content-boundary bump ends the direction poll; a locked warp no longer leaks `doorWarp` or strands a parked script; border tile reads use a floored modulo; the ball chain hides the wild mon while it shakes. |

## Goldens

**3 of 15 marks moved**, at both rungs, each explained in `docs/VOXEL.md` §7:
`battle-intro` because a two-line page now shows both lines, and
`encounter-seen` / `escaped` because the mark lands on the map instead of on
the battle screen. The other twelve are byte-identical — which is itself the
evidence that the overworld changes are audible or behavioural, not pictorial.

## Not fixed, and why

`docs/VOXEL.md` §11 records each with its reason: neighbour-map NPC ghosts
(wants an entity-budget measurement on device), `TWINEEDLE` /
`SWITCH_AND_TELEPORT` (want seams this slice lacks), item balls and the ball
supply (want the item-object interaction marts sit behind), ROM wording for
three lines (wants a `RomText` port and a sweep), and one-RNG-stream (kept
deliberately: changing it moves every hash to buy nothing visible).

## Gates

- `bun test` — 226 pass, 0 fail (18 new, pinning each closed gap)
- `bun tools/voxel.ts check` — green at both quality rungs
- EBOOT builds and **boots on a real PSP-2000** over PSPLINK

🤖 Generated with [Claude Code](https://claude.com/claude-code)