### PR TITLE
fix: stop dist and node_modules symlinks from reaching a commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
 # ROM-derived content NEVER commits (docs/VOXEL.md §1): everything the
 # importer and cooker produce lives here.
+#
+# Both spellings on purpose: a trailing slash matches a DIRECTORY only, so a
+# `dist` SYMLINK — which is how a second worktree borrows one cooked pak
+# instead of re-cooking 32 MB — slips past `dist/` and lands in a commit.
+/dist
+/node_modules
 dist/
 target/
 node_modules/

--- a/dist
+++ b/dist
@@ -1,1 +1,0 @@
-/Users/evan/code/pocket-voxel/dist

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/evan/code/pocket-voxel/node_modules


### PR DESCRIPTION
#2 committed two symlinks — `dist` and `node_modules`, mode `120000`,
pointing into my own checkout — because a `git add -A` in a second worktree
swept them up.

They were invisible to `.gitignore` for a reason worth writing down: a
trailing slash matches a **directory only**, and a worktree that borrows one
cooked pak instead of re-cooking 32 MB borrows it as a **symlink**. So `dist/`
never matched `dist`.

Untracks both and ignores each spelling. The working-tree symlinks survive —
they are how this worktree builds.