### PR TITLE
docs: a VitePress developer site over the design record

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,51 @@
+# Build and deploy the VitePress docs site to GitHub Pages.
+#
+# Needs Pages enabled once in the repo settings: Settings → Pages →
+# Source: "GitHub Actions". The site deploys to
+# https://pocket-stack.github.io/pocket-voxel/ (the base in
+# docs/.vitepress/config.mts must match the repo name).
+
+name: docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "package.json"
+      - "bun.lock"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # The docs build needs no submodules, no ROM and no reference
+      # checkouts — it is pure Markdown + the committed screenshots.
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run docs:build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.vitepress/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ node_modules/
 # Local Wrangler development state is machine-specific and may contain
 # transient cache/observability databases.
 /.wrangler/
+
+# VitePress build output and cache (docs site)
+docs/.vitepress/cache/
+docs/.vitepress/dist/

--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,65 @@
       "devDependencies": {
         "@types/bun": "^1.2.0",
         "@types/three": "^0.185.0",
+        "mermaid": "^11.16.1",
         "typescript": "^5.7.0",
+        "vitepress": "^1.6.4",
+        "vitepress-plugin-mermaid": "^2.0.17",
         "wrangler": "4.120.1",
       },
     },
   },
   "packages": {
+    "@algolia/abtesting": ["@algolia/abtesting@1.22.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-BFR6zNowNKcY7Ou7TaJc9QWexES4YKPbmf/OTFofpdsdhz4x6q0lbxp3duO0EHnyrN7rE4ba/TSXuY+BDGu4+g=="],
+
+    "@algolia/autocomplete-core": ["@algolia/autocomplete-core@1.17.7", "", { "dependencies": { "@algolia/autocomplete-plugin-algolia-insights": "1.17.7", "@algolia/autocomplete-shared": "1.17.7" } }, "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q=="],
+
+    "@algolia/autocomplete-plugin-algolia-insights": ["@algolia/autocomplete-plugin-algolia-insights@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "search-insights": ">= 1 < 3" } }, "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A=="],
+
+    "@algolia/autocomplete-preset-algolia": ["@algolia/autocomplete-preset-algolia@1.17.7", "", { "dependencies": { "@algolia/autocomplete-shared": "1.17.7" }, "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA=="],
+
+    "@algolia/autocomplete-shared": ["@algolia/autocomplete-shared@1.17.7", "", { "peerDependencies": { "@algolia/client-search": ">= 4.9.1 < 6", "algoliasearch": ">= 4.9.1 < 6" } }, "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg=="],
+
+    "@algolia/client-abtesting": ["@algolia/client-abtesting@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-7r4Z3NC7yU1oAQVWJNA2HX7tX481F3pJvCGyLIXiTdBcthz4Q/o21jwcMYDFkuI92UWTNBQQmHYgwHo1zS5dzg=="],
+
+    "@algolia/client-analytics": ["@algolia/client-analytics@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-avmjXQSq+jadFO8Xl2em05/uQdQnEmHsJyOAdVbZkmVgpMfxL12aJwVVfGNwYr9nulcpuJN1X0lTaQ5wxuNGcA=="],
+
+    "@algolia/client-common": ["@algolia/client-common@5.56.0", "", {}, "sha512-v2TPStUhY//ripPjIVclZ8AWc7DEGooXULZGFlFu37zNatgHjw34oZZ+OSbbc/YHO+xZwPl62I1k8xH1m4S2eg=="],
+
+    "@algolia/client-insights": ["@algolia/client-insights@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-P0ehROpM4Sem3Sqo5x2cKPgj67D3G3jy0rh1Amwkcvsfr6tkvIcdCmerieanqTF7NxUMPNFLkpIFeMO8Rpa50w=="],
+
+    "@algolia/client-personalization": ["@algolia/client-personalization@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-SXK3Vn3WVxyzbm31oePZBJkp1wpOyuWdd4B/Pv7n0aXDxmeSWhC1R1FC1517mMrFAIaPH4Rt0x6RUe7ZNjz8FA=="],
+
+    "@algolia/client-query-suggestions": ["@algolia/client-query-suggestions@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-5+ZdX8garFnmycnZgKhtXHePEaLj5zqDxI/0lkhhluzCcvTn0/PvvTirTg8hHYetQHvn7GDyeAiqTAieMvMW4A=="],
+
+    "@algolia/client-search": ["@algolia/client-search@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-+mKUdYvqOi0BcvpAEyCEw49vSBptufIcfibtHz2bdr1pI789M46Yt0uQEk/sxtK3teh71OQvVFHaTDzShUWewQ=="],
+
+    "@algolia/ingestion": ["@algolia/ingestion@1.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-9g/zj+AZx5moFcdFIrYQoVrueXivjUcc3MQHtCYT8WhIuk1lUh1AyEhvJCS0XBZld09cLvd1AZ3BvDBpVpX2UA=="],
+
+    "@algolia/monitoring": ["@algolia/monitoring@1.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-Qf3Sr6f9A9uxCZUf3MXS0d2b877uYzEB5yxqpVGXAhcJnBCQjrRRon0KvefpGkxy+BshrIJs96OUoMtGqXTFDA=="],
+
+    "@algolia/recommend": ["@algolia/recommend@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-GXWG1rWc5wu8hY4N33Y3b6ernY6sAdAvmKWN/zHAiACOx40WnpG0TVX5YazCAr/9gOYGInSiM2A0y2jy2xbiDA=="],
+
+    "@algolia/requester-browser-xhr": ["@algolia/requester-browser-xhr@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-7t24cBxaInS3mZb7ddEaZT/tp6q+/aR4YttsQVyP1/i+LmwPR34atO35KjaLFCcRVrlP7sYOAqkCfg6lIRB+ew=="],
+
+    "@algolia/requester-fetch": ["@algolia/requester-fetch@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-R7ePHgVYmDFjZpvrsVAfbDz/d4RxKAYZ5/vgLfIsCVRZRryjWl/3INOxpOICzitehQ5FjNtNjcLQTrmHPTcHBQ=="],
+
+    "@algolia/requester-node-http": ["@algolia/requester-node-http@5.56.0", "", { "dependencies": { "@algolia/client-common": "5.56.0" } }, "sha512-PIOUXlSnrqM0S+WOgDRb4RzotydJH7ZoT6tOyL7tAO7qJOfvX5wsEW8Pe+PMKMwvuI4/gIyK9cg2H7lJXqnc4Q=="],
+
+    "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/parser": ["@babel/parser@7.29.8", "", { "dependencies": { "@babel/types": "^7.29.8" }, "bin": "./bin/babel-parser.js" }, "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA=="],
+
+    "@babel/types": ["@babel/types@7.29.8", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg=="],
+
+    "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.2", "", {}, "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA=="],
+
+    "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
+
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
     "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
@@ -33,6 +86,12 @@
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@docsearch/css": ["@docsearch/css@3.8.2", "", {}, "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ=="],
+
+    "@docsearch/js": ["@docsearch/js@3.8.2", "", { "dependencies": { "@docsearch/react": "3.8.2", "preact": "^10.0.0" } }, "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ=="],
+
+    "@docsearch/react": ["@docsearch/react@3.8.2", "", { "dependencies": { "@algolia/autocomplete-core": "1.17.7", "@algolia/autocomplete-preset-algolia": "1.17.7", "@docsearch/css": "3.8.2", "algoliasearch": "^5.14.2" }, "peerDependencies": { "@types/react": ">= 16.8.0 < 19.0.0", "react": ">= 16.8.0 < 19.0.0", "react-dom": ">= 16.8.0 < 19.0.0", "search-insights": ">= 1 < 3" }, "optionalPeers": ["@types/react", "react", "react-dom", "search-insights"] }, "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
 
@@ -87,6 +146,12 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@iconify-json/simple-icons": ["@iconify-json/simple-icons@1.2.93", "", { "dependencies": { "@iconify/types": "*" } }, "sha512-/XhANjfGYOuqvSR3TmUnkQkINvQ4GVjVuukvymRbxtVFBvIq/yiXJqCDycKcQPT401OYT9H2vIY6ihAlz1QIAw=="],
+
+    "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
+
+    "@iconify/utils": ["@iconify/utils@3.1.4", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "import-meta-resolve": "^4.2.0" } }, "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw=="],
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
@@ -148,11 +213,83 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@mermaid-js/mermaid-mindmap": ["@mermaid-js/mermaid-mindmap@9.3.0", "", { "dependencies": { "@braintree/sanitize-url": "^6.0.0", "cytoscape": "^3.23.0", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.1.0", "d3": "^7.0.0", "khroma": "^2.0.0", "non-layered-tidy-tree-layout": "^2.0.2" } }, "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw=="],
+
+    "@mermaid-js/parser": ["@mermaid-js/parser@1.2.0", "", { "dependencies": { "@chevrotain/types": "~11.1.2" } }, "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA=="],
+
+    "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
     "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
 
     "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
 
     "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.62.4", "", { "os": "android", "cpu": "arm" }, "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.62.4", "", { "os": "android", "cpu": "arm64" }, "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.62.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.62.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.62.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.62.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.62.4", "", { "os": "linux", "cpu": "arm" }, "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.62.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.62.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.62.4", "", { "os": "linux", "cpu": "none" }, "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.62.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.62.4", "", { "os": "linux", "cpu": "x64" }, "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.62.4", "", { "os": "openbsd", "cpu": "x64" }, "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.62.4", "", { "os": "none", "cpu": "arm64" }, "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.62.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.62.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.62.4", "", { "os": "win32", "cpu": "x64" }, "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q=="],
+
+    "@shikijs/core": ["@shikijs/core@2.5.0", "", { "dependencies": { "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.4" } }, "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^3.1.0" } }, "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw=="],
+
+    "@shikijs/langs": ["@shikijs/langs@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w=="],
+
+    "@shikijs/themes": ["@shikijs/themes@2.5.0", "", { "dependencies": { "@shikijs/types": "2.5.0" } }, "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw=="],
+
+    "@shikijs/transformers": ["@shikijs/transformers@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/types": "2.5.0" } }, "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg=="],
+
+    "@shikijs/types": ["@shikijs/types@2.5.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
 
@@ -162,47 +299,395 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/d3": ["@types/d3@7.4.3", "", { "dependencies": { "@types/d3-array": "*", "@types/d3-axis": "*", "@types/d3-brush": "*", "@types/d3-chord": "*", "@types/d3-color": "*", "@types/d3-contour": "*", "@types/d3-delaunay": "*", "@types/d3-dispatch": "*", "@types/d3-drag": "*", "@types/d3-dsv": "*", "@types/d3-ease": "*", "@types/d3-fetch": "*", "@types/d3-force": "*", "@types/d3-format": "*", "@types/d3-geo": "*", "@types/d3-hierarchy": "*", "@types/d3-interpolate": "*", "@types/d3-path": "*", "@types/d3-polygon": "*", "@types/d3-quadtree": "*", "@types/d3-random": "*", "@types/d3-scale": "*", "@types/d3-scale-chromatic": "*", "@types/d3-selection": "*", "@types/d3-shape": "*", "@types/d3-time": "*", "@types/d3-time-format": "*", "@types/d3-timer": "*", "@types/d3-transition": "*", "@types/d3-zoom": "*" } }, "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww=="],
+
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-axis": ["@types/d3-axis@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw=="],
+
+    "@types/d3-brush": ["@types/d3-brush@3.0.6", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A=="],
+
+    "@types/d3-chord": ["@types/d3-chord@3.0.6", "", {}, "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-contour": ["@types/d3-contour@3.0.6", "", { "dependencies": { "@types/d3-array": "*", "@types/geojson": "*" } }, "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg=="],
+
+    "@types/d3-delaunay": ["@types/d3-delaunay@6.0.4", "", {}, "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw=="],
+
+    "@types/d3-dispatch": ["@types/d3-dispatch@3.0.7", "", {}, "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-dsv": ["@types/d3-dsv@3.0.7", "", {}, "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-fetch": ["@types/d3-fetch@3.0.7", "", { "dependencies": { "@types/d3-dsv": "*" } }, "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA=="],
+
+    "@types/d3-force": ["@types/d3-force@3.0.10", "", {}, "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw=="],
+
+    "@types/d3-format": ["@types/d3-format@3.0.4", "", {}, "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g=="],
+
+    "@types/d3-geo": ["@types/d3-geo@3.1.1", "", { "dependencies": { "@types/geojson": "*" } }, "sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w=="],
+
+    "@types/d3-hierarchy": ["@types/d3-hierarchy@3.1.7", "", {}, "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-polygon": ["@types/d3-polygon@3.0.2", "", {}, "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA=="],
+
+    "@types/d3-quadtree": ["@types/d3-quadtree@3.0.6", "", {}, "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg=="],
+
+    "@types/d3-random": ["@types/d3-random@3.0.4", "", {}, "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-scale-chromatic": ["@types/d3-scale-chromatic@3.1.0", "", {}, "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-time-format": ["@types/d3-time-format@4.0.3", "", {}, "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@types/geojson": ["@types/geojson@7946.0.16", "", {}, "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg=="],
+
+    "@types/hast": ["@types/hast@3.0.5", "", { "dependencies": { "@types/unist": "*" } }, "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g=="],
+
+    "@types/linkify-it": ["@types/linkify-it@5.0.0", "", {}, "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="],
+
+    "@types/markdown-it": ["@types/markdown-it@14.1.2", "", { "dependencies": { "@types/linkify-it": "^5", "@types/mdurl": "^2" } }, "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
+
     "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
 
     "@types/three": ["@types/three@0.185.4", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA=="],
 
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+
     "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.3", "", {}, "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg=="],
+
+    "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
+
+    "@vitejs/plugin-vue": ["@vitejs/plugin-vue@5.2.4", "", { "peerDependencies": { "vite": "^5.0.0 || ^6.0.0", "vue": "^3.2.25" } }, "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.41", "", { "dependencies": { "@babel/parser": "^7.29.8", "@vue/shared": "3.5.41", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.41", "", { "dependencies": { "@vue/compiler-core": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.41", "", { "dependencies": { "@babel/parser": "^7.29.8", "@vue/compiler-core": "3.5.41", "@vue/compiler-dom": "3.5.41", "@vue/compiler-ssr": "3.5.41", "@vue/shared": "3.5.41", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.19", "source-map-js": "^1.2.1" } }, "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.41", "", { "dependencies": { "@vue/compiler-dom": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A=="],
+
+    "@vue/devtools-api": ["@vue/devtools-api@7.7.10", "", { "dependencies": { "@vue/devtools-kit": "^7.7.10" } }, "sha512-KxtEpUOOpFz/qOGRrAwA36QF7DqIA+FXgCYit9mk9wjbaZt0sXOFz81ElOZtKA4HbWHUdwNjZHBFsFFyp5BZiA=="],
+
+    "@vue/devtools-kit": ["@vue/devtools-kit@7.7.10", "", { "dependencies": { "@vue/devtools-shared": "^7.7.10", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-3WNi2Kq4tbpVbmhml7RiphmAt0279oh3fKNeWMQIrltfX8Q91b4i5PL8DtyNKdwmcsGrV4fg+erwWOmD05CLIw=="],
+
+    "@vue/devtools-shared": ["@vue/devtools-shared@7.7.10", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-wOPslzB8vTvpxwdaOcR2qAbwmuSP0L+rhpoC6Cf56V3Jip+HWb7PQQXOUPgBNQARpXsbQX/+mvi8kKucmBGRwQ=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.41", "", { "dependencies": { "@vue/shared": "3.5.41" } }, "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.41", "", { "dependencies": { "@vue/reactivity": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-Vcry58hiAKwGen9Z1jUZE0feFsNArPCMOImYI8el48A9Idf6DuQYD0U05zZIF2Iad1hGhPSvcbBbAOhNr55fhg=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.41", "", { "dependencies": { "@vue/reactivity": "3.5.41", "@vue/runtime-core": "3.5.41", "@vue/shared": "3.5.41", "csstype": "^3.2.3" } }, "sha512-3vVBahVBS9+U6cmXBLyb8nE6/yYo4J/CGI9eVFs3KiMc0YHuudwKyShTD65jtJy/L9PUUxNAFu4cj4LiJ0UFbw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.41", "", { "dependencies": { "@vue/compiler-ssr": "3.5.41", "@vue/runtime-dom": "3.5.41", "@vue/shared": "3.5.41" } }, "sha512-n6hx/pNFfbD6SuyeuMVkvqox8bwf/ET9JlA/kAz/imw8sw++wkqKe2mHX5KutjPpbKE4Z56yTHszoOjGMI9igQ=="],
+
+    "@vue/shared": ["@vue/shared@3.5.41", "", {}, "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA=="],
+
+    "@vueuse/core": ["@vueuse/core@12.8.2", "", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" } }, "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ=="],
+
+    "@vueuse/integrations": ["@vueuse/integrations@12.8.2", "", { "dependencies": { "@vueuse/core": "12.8.2", "@vueuse/shared": "12.8.2", "vue": "^3.5.13" }, "peerDependencies": { "async-validator": "^4", "axios": "^1", "change-case": "^5", "drauu": "^0.4", "focus-trap": "^7", "fuse.js": "^7", "idb-keyval": "^6", "jwt-decode": "^4", "nprogress": "^0.2", "qrcode": "^1.5", "sortablejs": "^1", "universal-cookie": "^7" }, "optionalPeers": ["async-validator", "axios", "change-case", "drauu", "focus-trap", "fuse.js", "idb-keyval", "jwt-decode", "nprogress", "qrcode", "sortablejs", "universal-cookie"] }, "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g=="],
+
+    "@vueuse/metadata": ["@vueuse/metadata@12.8.2", "", {}, "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A=="],
+
+    "@vueuse/shared": ["@vueuse/shared@12.8.2", "", { "dependencies": { "vue": "^3.5.13" } }, "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w=="],
+
+    "algoliasearch": ["algoliasearch@5.56.0", "", { "dependencies": { "@algolia/abtesting": "1.22.0", "@algolia/client-abtesting": "5.56.0", "@algolia/client-analytics": "5.56.0", "@algolia/client-common": "5.56.0", "@algolia/client-insights": "5.56.0", "@algolia/client-personalization": "5.56.0", "@algolia/client-query-suggestions": "5.56.0", "@algolia/client-search": "5.56.0", "@algolia/ingestion": "1.56.0", "@algolia/monitoring": "1.56.0", "@algolia/recommend": "5.56.0", "@algolia/requester-browser-xhr": "5.56.0", "@algolia/requester-fetch": "5.56.0", "@algolia/requester-node-http": "5.56.0" } }, "sha512-PrqppUmhT4ENdas2pH9caE7efUcxy6EcSFhWzosiVuQBzu2tQ5yLTI6jwomT/1cuBnivzGfxiJCqDNN9FRRh+Q=="],
+
+    "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
 
     "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "copy-anything": ["copy-anything@4.0.5", "", { "dependencies": { "is-what": "^5.2.0" } }, "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA=="],
+
+    "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "cytoscape": ["cytoscape@3.34.0", "", {}, "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg=="],
+
+    "cytoscape-cose-bilkent": ["cytoscape-cose-bilkent@4.1.0", "", { "dependencies": { "cose-base": "^1.0.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ=="],
+
+    "cytoscape-fcose": ["cytoscape-fcose@2.2.0", "", { "dependencies": { "cose-base": "^2.2.0" }, "peerDependencies": { "cytoscape": "^3.2.0" } }, "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ=="],
+
+    "d3": ["d3@7.9.0", "", { "dependencies": { "d3-array": "3", "d3-axis": "3", "d3-brush": "3", "d3-chord": "3", "d3-color": "3", "d3-contour": "4", "d3-delaunay": "6", "d3-dispatch": "3", "d3-drag": "3", "d3-dsv": "3", "d3-ease": "3", "d3-fetch": "3", "d3-force": "3", "d3-format": "3", "d3-geo": "3", "d3-hierarchy": "3", "d3-interpolate": "3", "d3-path": "3", "d3-polygon": "3", "d3-quadtree": "3", "d3-random": "3", "d3-scale": "4", "d3-scale-chromatic": "3", "d3-selection": "3", "d3-shape": "3", "d3-time": "3", "d3-time-format": "4", "d3-timer": "3", "d3-transition": "3", "d3-zoom": "3" } }, "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA=="],
+
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-axis": ["d3-axis@3.0.0", "", {}, "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="],
+
+    "d3-brush": ["d3-brush@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "3", "d3-transition": "3" } }, "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ=="],
+
+    "d3-chord": ["d3-chord@3.0.1", "", { "dependencies": { "d3-path": "1 - 3" } }, "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-contour": ["d3-contour@4.0.2", "", { "dependencies": { "d3-array": "^3.2.0" } }, "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA=="],
+
+    "d3-delaunay": ["d3-delaunay@6.0.4", "", { "dependencies": { "delaunator": "5" } }, "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-dsv": ["d3-dsv@3.0.1", "", { "dependencies": { "commander": "7", "iconv-lite": "0.6", "rw": "1" }, "bin": { "csv2json": "bin/dsv2json.js", "csv2tsv": "bin/dsv2dsv.js", "dsv2dsv": "bin/dsv2dsv.js", "dsv2json": "bin/dsv2json.js", "json2csv": "bin/json2dsv.js", "json2dsv": "bin/json2dsv.js", "json2tsv": "bin/json2dsv.js", "tsv2csv": "bin/dsv2dsv.js", "tsv2json": "bin/dsv2json.js" } }, "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-fetch": ["d3-fetch@3.0.1", "", { "dependencies": { "d3-dsv": "1 - 3" } }, "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw=="],
+
+    "d3-force": ["d3-force@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-quadtree": "1 - 3", "d3-timer": "1 - 3" } }, "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-geo": ["d3-geo@3.1.1", "", { "dependencies": { "d3-array": "2.5.0 - 3" } }, "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-polygon": ["d3-polygon@3.0.1", "", {}, "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="],
+
+    "d3-quadtree": ["d3-quadtree@3.0.1", "", {}, "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="],
+
+    "d3-random": ["d3-random@3.0.1", "", {}, "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="],
+
+    "d3-sankey": ["d3-sankey@0.12.3", "", { "dependencies": { "d3-array": "1 - 2", "d3-shape": "^1.2.0" } }, "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-scale-chromatic": ["d3-scale-chromatic@3.1.0", "", { "dependencies": { "d3-color": "1 - 3", "d3-interpolate": "1 - 3" } }, "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "dagre-d3-es": ["dagre-d3-es@7.0.14", "", { "dependencies": { "d3": "^7.9.0", "lodash-es": "^4.17.21" } }, "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg=="],
+
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
+    "delaunator": ["delaunator@5.1.0", "", { "dependencies": { "robust-predicates": "^3.0.2" } }, "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "dompurify": ["dompurify@3.4.13", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ=="],
+
+    "emoji-regex-xs": ["emoji-regex-xs@1.0.0", "", {}, "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="],
+
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-toolkit": ["es-toolkit@1.50.0", "", {}, "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w=="],
 
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
     "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
+
+    "focus-trap": ["focus-trap@7.8.0", "", { "dependencies": { "tabbable": "^6.4.0" } }, "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "import-meta-resolve": ["import-meta-resolve@4.2.0", "", {}, "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "is-what": ["is-what@5.5.0", "", {}, "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw=="],
+
+    "katex": ["katex@0.16.47", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg=="],
+
+    "khroma": ["khroma@2.1.0", "", {}, "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="],
+
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "layout-base": ["layout-base@1.0.2", "", {}, "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="],
+
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
+
+    "marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mermaid": ["mermaid@11.16.1", "", { "dependencies": { "@braintree/sanitize-url": "^7.1.2", "@iconify/utils": "^3.0.2", "@mermaid-js/parser": "^1.2.0", "@types/d3": "^7.4.3", "@upsetjs/venn.js": "^2.0.0", "cytoscape": "^3.33.3", "cytoscape-cose-bilkent": "^4.1.0", "cytoscape-fcose": "^2.2.0", "d3": "^7.9.0", "d3-sankey": "^0.12.3", "dagre-d3-es": "7.0.14", "dayjs": "^1.11.20", "dompurify": "^3.3.3", "es-toolkit": "^1.45.1", "katex": "^0.16.45", "khroma": "^2.1.0", "marked": "^16.3.0", "roughjs": "^4.6.6", "stylis": "^4.3.6", "ts-dedent": "^2.2.0", "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0" } }, "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g=="],
 
     "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
     "miniflare": ["miniflare@5.20260804.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260804.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-UDegnTukIpJCI/lNyQXU7B8kYFLcMZihlxqqOocnc62tV8AO6XofmFmZm3ZLDXTWZpkZnLLJ2sKCSlTIEXO3dQ=="],
+
+    "minisearch": ["minisearch@7.2.0", "", {}, "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="],
+
+    "mitt": ["mitt@3.0.1", "", {}, "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw=="],
+
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "non-layered-tidy-tree-layout": ["non-layered-tidy-tree-layout@2.0.2", "", {}, "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@3.1.1", "", { "dependencies": { "emoji-regex-xs": "^1.0.0", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ=="],
+
+    "package-manager-detector": ["package-manager-detector@1.8.0", "", {}, "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A=="],
+
+    "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
+    "perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "points-on-curve": ["points-on-curve@0.2.0", "", {}, "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="],
+
+    "points-on-path": ["points-on-path@0.2.1", "", { "dependencies": { "path-data-parser": "0.1.0", "points-on-curve": "0.2.0" } }, "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g=="],
+
+    "postcss": ["postcss@8.5.26", "", { "dependencies": { "nanoid": "^3.3.17", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ=="],
+
+    "preact": ["preact@10.29.8", "", { "peerDependencies": { "preact-render-to-string": ">=5" }, "optionalPeers": ["preact-render-to-string"] }, "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "robust-predicates": ["robust-predicates@3.0.3", "", {}, "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA=="],
+
+    "rollup": ["rollup@4.62.4", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.62.4", "@rollup/rollup-android-arm64": "4.62.4", "@rollup/rollup-darwin-arm64": "4.62.4", "@rollup/rollup-darwin-x64": "4.62.4", "@rollup/rollup-freebsd-arm64": "4.62.4", "@rollup/rollup-freebsd-x64": "4.62.4", "@rollup/rollup-linux-arm-gnueabihf": "4.62.4", "@rollup/rollup-linux-arm-musleabihf": "4.62.4", "@rollup/rollup-linux-arm64-gnu": "4.62.4", "@rollup/rollup-linux-arm64-musl": "4.62.4", "@rollup/rollup-linux-loong64-gnu": "4.62.4", "@rollup/rollup-linux-loong64-musl": "4.62.4", "@rollup/rollup-linux-ppc64-gnu": "4.62.4", "@rollup/rollup-linux-ppc64-musl": "4.62.4", "@rollup/rollup-linux-riscv64-gnu": "4.62.4", "@rollup/rollup-linux-riscv64-musl": "4.62.4", "@rollup/rollup-linux-s390x-gnu": "4.62.4", "@rollup/rollup-linux-x64-gnu": "4.62.4", "@rollup/rollup-linux-x64-musl": "4.62.4", "@rollup/rollup-openbsd-x64": "4.62.4", "@rollup/rollup-openharmony-arm64": "4.62.4", "@rollup/rollup-win32-arm64-msvc": "4.62.4", "@rollup/rollup-win32-ia32-msvc": "4.62.4", "@rollup/rollup-win32-x64-gnu": "4.62.4", "@rollup/rollup-win32-x64-msvc": "4.62.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg=="],
+
+    "roughjs": ["roughjs@4.6.6", "", { "dependencies": { "hachure-fill": "^0.5.2", "path-data-parser": "^0.1.0", "points-on-curve": "^0.2.0", "points-on-path": "^0.2.1" } }, "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ=="],
+
+    "rw": ["rw@1.3.3", "", {}, "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "search-insights": ["search-insights@2.17.3", "", {}, "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ=="],
+
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
     "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
 
+    "shiki": ["shiki@2.5.0", "", { "dependencies": { "@shikijs/core": "2.5.0", "@shikijs/engine-javascript": "2.5.0", "@shikijs/engine-oniguruma": "2.5.0", "@shikijs/langs": "2.5.0", "@shikijs/themes": "2.5.0", "@shikijs/types": "2.5.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "speakingurl": ["speakingurl@14.0.1", "", {}, "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "stylis": ["stylis@4.4.0", "", {}, "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA=="],
+
+    "superjson": ["superjson@2.2.6", "", { "dependencies": { "copy-anything": "^4" } }, "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA=="],
+
     "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
+    "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
+
     "three": ["three@0.185.1", "", {}, "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "ts-dedent": ["ts-dedent@2.3.0", "", {}, "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -214,6 +699,30 @@
 
     "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
 
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vitepress": ["vitepress@1.6.4", "", { "dependencies": { "@docsearch/css": "3.8.2", "@docsearch/js": "3.8.2", "@iconify-json/simple-icons": "^1.2.21", "@shikijs/core": "^2.1.0", "@shikijs/transformers": "^2.1.0", "@shikijs/types": "^2.1.0", "@types/markdown-it": "^14.1.2", "@vitejs/plugin-vue": "^5.2.1", "@vue/devtools-api": "^7.7.0", "@vue/shared": "^3.5.13", "@vueuse/core": "^12.4.0", "@vueuse/integrations": "^12.4.0", "focus-trap": "^7.6.4", "mark.js": "8.11.1", "minisearch": "^7.1.1", "shiki": "^2.1.0", "vite": "^5.4.14", "vue": "^3.5.13" }, "peerDependencies": { "markdown-it-mathjax3": "^4", "postcss": "^8" }, "optionalPeers": ["markdown-it-mathjax3", "postcss"], "bin": { "vitepress": "bin/vitepress.js" } }, "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg=="],
+
+    "vitepress-plugin-mermaid": ["vitepress-plugin-mermaid@2.0.17", "", { "optionalDependencies": { "@mermaid-js/mermaid-mindmap": "^9.3.0" }, "peerDependencies": { "mermaid": "10 || 11", "vitepress": "^1.0.0 || ^1.0.0-alpha" } }, "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg=="],
+
+    "vue": ["vue@3.5.41", "", { "dependencies": { "@vue/compiler-dom": "3.5.41", "@vue/compiler-sfc": "3.5.41", "@vue/runtime-dom": "3.5.41", "@vue/server-renderer": "3.5.41", "@vue/shared": "3.5.41" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-2laE0p+aK+/AOPG/XL/WepOs/GlK755LJ1XECi9kDUrz1FKNw8rb2Xzlw9JS1rqEV55nb0ttsKxVlTCcd+R5cg=="],
+
     "workerd": ["workerd@1.20260804.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260804.1", "@cloudflare/workerd-darwin-arm64": "1.20260804.1", "@cloudflare/workerd-linux-64": "1.20260804.1", "@cloudflare/workerd-linux-arm64": "1.20260804.1", "@cloudflare/workerd-windows-64": "1.20260804.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-b0P38g5/ssemwWxd/mafNYggEZ0ere7PCiUH6RCHkgqjRhhXTP45nDiL2L3iIvi8uF2IjNrGpVgMXEunCaeY/w=="],
 
     "wrangler": ["wrangler@4.120.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260804.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260804.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260804.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-rQJ38rY02XiVITbSBWHC7oap3M2evcXgsC4CdlIX4WQENUZMMnue9j2vXO4aIi39KR+jDH+UHK8JNqp1+UjkRQ=="],
@@ -223,5 +732,71 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@mermaid-js/mermaid-mindmap/@braintree/sanitize-url": ["@braintree/sanitize-url@6.0.4", "", {}, "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A=="],
+
+    "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
+
+    "d3-dsv/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
+
+    "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "cytoscape-fcose/cose-base/layout-base": ["layout-base@2.0.1", "", {}, "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="],
+
+    "d3-sankey/d3-array/internmap": ["internmap@1.0.1", "", {}, "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="],
+
+    "d3-sankey/d3-shape/d3-path": ["d3-path@1.0.9", "", {}, "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
   }
 }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,0 +1,96 @@
+import { withMermaid } from "vitepress-plugin-mermaid";
+
+// Deployed as a GitHub Pages project site; the base must match the repo name.
+export default withMermaid({
+  title: "Pocket Voxel",
+  description:
+    "A Game Boy creature-RPG as a voxelized 3D diorama on a real PSP and PS Vita — one cooked pak, one guest bundle, deterministic to the byte.",
+  base: "/pocket-voxel/",
+  lastUpdated: true,
+
+  head: [
+    [
+      "link",
+      {
+        rel: "icon",
+        href: "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🧊</text></svg>",
+      },
+    ],
+    ["meta", { name: "theme-color", content: "#2fbf71" }],
+  ],
+
+  themeConfig: {
+    nav: [
+      { text: "Guide", link: "/guide/getting-started", activeMatch: "/guide/" },
+      { text: "Reference", link: "/reference/cli", activeMatch: "/reference/" },
+      { text: "Design Record", link: "/VOXEL" },
+    ],
+
+    sidebar: [
+      {
+        text: "Guide",
+        items: [
+          { text: "Getting Started", link: "/guide/getting-started" },
+          { text: "Architecture", link: "/guide/architecture" },
+          { text: "The Asset Pipeline", link: "/guide/pipeline" },
+          { text: "The Quality Ladder", link: "/guide/quality-ladder" },
+          { text: "Running on PSP", link: "/guide/psp" },
+          { text: "Running on PS Vita", link: "/guide/vita" },
+          { text: "Testing & Determinism", link: "/guide/testing" },
+        ],
+      },
+      {
+        text: "Reference",
+        items: [
+          { text: "CLI — tools/voxel.ts", link: "/reference/cli" },
+          { text: "The Voxel Surface", link: "/reference/surface" },
+          { text: "Data & Formats", link: "/reference/formats" },
+          { text: "Glossary", link: "/reference/glossary" },
+        ],
+      },
+      {
+        text: "Project",
+        items: [
+          { text: "Contributing", link: "/contributing" },
+          { text: "Design Record (VOXEL.md)", link: "/VOXEL" },
+        ],
+      },
+    ],
+
+    socialLinks: [
+      { icon: "github", link: "https://github.com/pocket-stack/pocket-voxel" },
+    ],
+
+    editLink: {
+      pattern:
+        "https://github.com/pocket-stack/pocket-voxel/edit/main/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+
+    search: { provider: "local" },
+
+    outline: { level: [2, 3] },
+
+    footer: {
+      message:
+        "MIT Licensed. The ROM, and everything derived from it, stays yours and stays local.",
+      copyright: "© Pocket Voxel contributors",
+    },
+  },
+
+  // Mermaid renders client-side; fixed light node fills + dark node text stay
+  // readable on both themes, and edge labels are re-themed in custom.css.
+  mermaid: {
+    theme: "base",
+    themeVariables: {
+      primaryColor: "#ecfdf4",
+      primaryTextColor: "#14261d",
+      primaryBorderColor: "#2fbf71",
+      lineColor: "#94a3b8",
+      edgeLabelBackground: "transparent",
+      fontSize: "14px",
+    },
+    fontFamily:
+      "'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif",
+  },
+});

--- a/docs/.vitepress/theme/custom.css
+++ b/docs/.vitepress/theme/custom.css
@@ -1,0 +1,327 @@
+/**
+ * Pocket Voxel theme — the diorama's grass green fading into GB-screen teal.
+ * Everything here layers over the default theme; no component overrides.
+ */
+
+:root {
+  --vp-c-brand-1: #1fa25c;
+  --vp-c-brand-2: #26b167;
+  --vp-c-brand-3: #2fbf71;
+  --vp-c-brand-soft: rgba(47, 191, 113, 0.14);
+
+  /* hero title gradient */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(
+    115deg,
+    #42d392 15%,
+    #22d3ee 55%,
+    #647eff
+  );
+
+  --vp-button-brand-bg: var(--vp-c-brand-3);
+  --vp-button-brand-hover-bg: var(--vp-c-brand-2);
+}
+
+.dark {
+  --vp-c-brand-1: #42d392;
+  --vp-c-brand-2: #35c885;
+  --vp-c-brand-3: #2fbf71;
+  --vp-c-brand-soft: rgba(66, 211, 146, 0.16);
+}
+
+/* ---------------------------------------------------------------- home -- */
+
+/* stat badges under the hero */
+.pv-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin: 24px 0 8px;
+}
+.pv-badges span {
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 7px 13px;
+  border-radius: 999px;
+  color: var(--vp-c-brand-1);
+  background: var(--vp-c-brand-soft);
+  border: 1px solid color-mix(in srgb, var(--vp-c-brand-1) 25%, transparent);
+  white-space: nowrap;
+}
+
+/* the wide lead screenshot, with a glow bed behind it */
+.pv-hero-shot {
+  position: relative;
+  max-width: 780px;
+  margin: 40px auto 8px;
+}
+.pv-hero-shot::before {
+  content: "";
+  position: absolute;
+  inset: -8%;
+  background: radial-gradient(
+    closest-side,
+    rgba(66, 211, 146, 0.3),
+    rgba(34, 211, 238, 0.12) 55%,
+    transparent 75%
+  );
+  filter: blur(42px);
+  z-index: -1;
+}
+.pv-hero-shot img {
+  width: 100%;
+  border-radius: 14px;
+  image-rendering: pixelated;
+  box-shadow: 0 16px 56px rgba(0, 0, 0, 0.45);
+}
+.pv-hero-shot figcaption {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  text-align: center;
+  padding-top: 12px;
+}
+
+/* smaller screenshot pairs */
+.pv-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+  margin: 24px 0;
+}
+.pv-gallery figure {
+  margin: 0;
+}
+.pv-gallery img {
+  width: 100%;
+  border-radius: 12px;
+  image-rendering: pixelated;
+  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.35);
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.25s ease;
+}
+.pv-gallery img:hover {
+  transform: translateY(-4px) scale(1.015);
+  box-shadow: 0 18px 52px rgba(47, 191, 113, 0.28);
+}
+.pv-gallery figcaption {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  text-align: center;
+  padding-top: 10px;
+}
+
+/* ------------------------------------------------------------ mermaid -- */
+
+.vp-doc .mermaid {
+  display: flex;
+  justify-content: center;
+  margin: 20px 0;
+  overflow-x: auto;
+}
+.vp-doc .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+
+/* .vp-doc typography (28px line-height, 16px paragraph margins) leaks into
+   mermaid's HTML labels and inflates them past the boxes mermaid measured —
+   text gets clipped and edge-label backgrounds detach into stray bars.
+   Neutralize it inside the diagram. */
+.vp-doc .mermaid p {
+  margin: 0 !important;
+  line-height: 1.45 !important;
+}
+.vp-doc .mermaid .nodeLabel,
+.vp-doc .mermaid .edgeLabel,
+.vp-doc .mermaid foreignObject div {
+  line-height: 1.45 !important;
+}
+.vp-doc .mermaid .nodeLabel small {
+  display: inline-block;
+  margin-top: 3px;
+  font-size: 12px;
+  line-height: 1.55;
+  opacity: 0.78;
+}
+
+/* edge labels: kill mermaid's translucent .labelBkg layer, then paint only
+   the <p> with the page background so the label reads as one floating
+   caption that masks the line in both themes */
+.vp-doc .mermaid .labelBkg {
+  background: transparent !important;
+}
+.vp-doc .mermaid .edgeLabel {
+  color: var(--vp-c-text-2) !important;
+  background-color: transparent !important;
+  font-size: 12px;
+}
+.vp-doc .mermaid .edgeLabel p {
+  color: var(--vp-c-text-2) !important;
+  background-color: var(--vp-c-bg) !important;
+  border-radius: 6px;
+  padding: 2px 7px;
+}
+
+/* pipeline diagram: two stages hinged on the pak node */
+.pv-pipeline {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 14px;
+  align-items: stretch;
+  margin: 28px 0 4px;
+}
+.pv-stage {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 14px;
+  padding: 18px;
+  background: var(--vp-c-bg-soft);
+}
+.pv-stage-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 14px;
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vp-c-brand-1);
+}
+.pv-stage-title span {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--vp-c-text-3);
+}
+.pv-node {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  padding: 10px 14px;
+  background: var(--vp-c-bg);
+}
+.pv-node b {
+  display: block;
+  font-size: 14px;
+  line-height: 1.5;
+}
+.pv-node small {
+  display: block;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+.pv-node small code {
+  font-size: 11px;
+  padding: 1px 5px;
+}
+.pv-node-pak {
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 55%, transparent);
+  background: var(--vp-c-brand-soft);
+  box-shadow: 0 0 26px rgba(66, 211, 146, 0.16);
+}
+.pv-node-pak b {
+  color: var(--vp-c-brand-1);
+}
+.pv-arrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 5px 0;
+  color: var(--vp-c-text-3);
+}
+.pv-arrow i {
+  font-style: normal;
+  font-size: 14px;
+  color: color-mix(in srgb, var(--vp-c-brand-1) 70%, var(--vp-c-text-3));
+}
+.pv-arrow em {
+  font-style: normal;
+  font-size: 11.5px;
+  line-height: 1;
+  padding: 3px 9px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 999px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  white-space: nowrap;
+}
+.pv-flow {
+  display: flex;
+  align-items: center;
+}
+.pv-flow i {
+  font-style: normal;
+  font-size: 20px;
+  color: var(--vp-c-brand-1);
+}
+.pv-machines {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-top: auto;
+}
+.pv-machine {
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 10px;
+  padding: 9px 6px;
+  background: var(--vp-c-bg);
+  text-align: center;
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease;
+}
+.pv-machine:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 60%, transparent);
+}
+.pv-machine b {
+  display: block;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.pv-machine small {
+  display: block;
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+}
+.pv-pipeline-foot {
+  margin: 10px 0 24px;
+  text-align: center;
+}
+.pv-pipeline-foot p {
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+}
+@media (max-width: 719px) {
+  .pv-pipeline {
+    grid-template-columns: 1fr;
+  }
+  .pv-flow {
+    justify-content: center;
+  }
+  .pv-flow i {
+    transform: rotate(90deg);
+  }
+  .pv-machines {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* feature cards: lift on hover, brand ring */
+.VPFeature {
+  transition:
+    transform 0.2s ease,
+    border-color 0.2s ease;
+}
+.VPFeature:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--vp-c-brand-1) 45%, transparent);
+}

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,4 @@
+import DefaultTheme from "vitepress/theme";
+import "./custom.css";
+
+export default DefaultTheme;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,86 @@
+# Contributing
+
+The codebase is opinionated in a few places where being casual has already
+been measured to hurt. Read this page before your first PR; it is short and
+every rule on it has a story behind it (usually in [VOXEL.md](/VOXEL)).
+
+## The hard rules
+
+1. **No ROM-derived byte is ever committed.** No cooked pak, no extracted
+   art, no decoded text, no golden PNG. Goldens are frame *hashes*. If your
+   change wants to commit a picture, capture real hardware output (the XMB
+   art standard) or don't.
+2. **The identity anchor is not yours to move.** `*-max.hashes` are never
+   re-recorded for a dial edit. The three legitimate re-basing events — a
+   vertex format change, a pack order change, a gameplay change — each pay
+   with a pixel-diff proof: which marks moved, by how many pixels, and why
+   each had to. See [the golden ceremony](/guide/testing#the-golden-ceremony).
+3. **No camera-relative representation change inside the visible field.** A
+   distance boundary that moves with the player plays as flicker on device.
+   New fidelity work uses uniform dials, or cooks all levels and keeps the
+   boundary out of the frustum. See
+   [the no-moving-boundary rule](/guide/quality-ladder#the-no-moving-boundary-rule).
+4. **The 24 px underside cull is a pak invariant.** Anything that lowers a
+   camera eye below 24 world px — a new rig, a lower rig height, a new pitch
+   rung — invalidates every cooked pak, not just the cooker. Say so in the PR
+   if you touch a rig.
+5. **Gameplay formulas cite their provenance.** Every ported rule carries a
+   citation to the Lua it ports. A change to a rules module either matches
+   the reference at its cited lines or declares an adaptation the way
+   `rules/status.ts` does.
+6. **The surface changes by ceremony.** Edit `contracts/spec/voxel-spec.ts`,
+   regenerate the Rust (`gen-voxel-rust.ts`), commit both — the byte-compare
+   drift guard fails the build otherwise.
+
+## Before you push
+
+```sh
+bun run tsc                  # typecheck
+bun test                     # 226 tests; ROM-gated suites skip without inputs
+bun tools/voxel.ts check     # both tapes, both rungs, against the goldens
+```
+
+If your change legitimately moves the **shipped**-rung picture (a dial
+change), run `bun tools/voxel.ts record`, commit the updated hashes, and put
+the accounting in the PR: which marks moved and why each one had to. Use
+`bun tools/voxel.ts shots` to eyeball, and the PPSSPP e2e to prove the GE
+agrees.
+
+If `check` goes red at the `-max` tier: stop. The fix is in your change,
+never in the golden file.
+
+## Layout
+
+```text
+crates/pocketvoxel-core     scene core (no_std + alloc, zero deps)
+crates/pocketvoxel-sim      desktop headless host: rasterizer, PNGs, hashes
+crates/pocketvoxel-gu       PSP sceGu backend
+crates/pocketvoxel-psp      the EBOOT shell
+crates/pocketvoxel-gxm      Vita raw-GXM backend
+crates/pocketvoxel-vita     the VPK shell
+voxelmon/import             ROM importer (TS)
+voxelmon/cook               voxelizer + atlas packer + VXPK writer (TS)
+voxelmon/game               the gameplay port (TS) — Bun headless and QuickJS
+voxelmon/tapes              intent tapes
+contracts/spec              the surface spec + Rust codegen
+tools/voxel.ts              the pipeline command
+tests/                      suites + goldens (hashes only)
+vendor/pocketjs             the engine, pinned as a submodule
+```
+
+The submodule pin moves deliberately: the PSP host library, the audio module
+and the toolchain pins all come from one mainline engine commit.
+
+## Working on these docs
+
+The site lives in `docs/` and builds with VitePress:
+
+```sh
+bun run docs:dev       # local dev server with hot reload
+bun run docs:build     # production build (also validates links)
+bun run docs:preview   # serve the built site
+```
+
+`docs/VOXEL.md` is the design record — a decision log, not a manual. Keep it
+append-oriented and let these pages stay the readable layer that links into
+it; don't duplicate a fact in both places when a link will do.

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -1,0 +1,125 @@
+# Architecture
+
+Pocket Voxel is a specialized runtime of
+[PocketJS](https://github.com/pocket-stack/pocketjs): the composition is
+`⟨ pocketvoxel-core, the voxel surface, the voxelmon guest ⟩`. What makes it
+unusual among PocketJS runtimes is that the ownership split is **inverted**:
+the game state lives in the guest, and the Rust core owns only the
+presentation.
+
+Pocket Mon put world+battle in Rust and authored content in TypeScript.
+Pocket Voxel puts world+battle in TypeScript and gives Rust the scene — the
+same relationship a retained-mode UI surface has with its guest, applied to a
+3D diorama.
+
+```mermaid
+flowchart TD
+    guest["<b>QuickJS guest</b> · TypeScript, voxelmon/game/<br/><small>world · battle · script VM · menus · text · saves · RNG<br/>one frame(buttons) per host tick</small>"]
+    core["<b>pocketvoxel-core</b> · Rust — no_std + alloc, zero deps<br/><small>VXPK reader · chunk culling · retained scene · camera rungs<br/>battle staging · GB UI tile layer · chip synth</small>"]
+    list(["one ordered draw list per frame"])
+    gu["<b>pocketvoxel-gu</b><br/><small>PSP · sceGu</small>"]
+    gxm["<b>pocketvoxel-gxm</b><br/><small>Vita · raw GXM</small>"]
+    sim["<b>pocketvoxel-sim</b><br/><small>desktop · software raster</small>"]
+
+    guest -->|"the voxel surface · ~10–40 ops/tick"| core
+    core --> list
+    list --> gu
+    list --> gxm
+    list --> sim
+```
+
+## The guest owns the game
+
+The entire [gen1recomp](https://github.com/bryanthaboi/gen1recomp) gameplay
+surface, ported module-for-module with the Lua as executable spec: fixed
+60 Hz step, edge-per-step input, map loading and connections, grid movement
+and collision (bottom-left-tile rule), ledges, warps, doors, NPC wander and
+scripted moves, trainer sight, encounters, the script runner and its verbs,
+text pagination, menus, party/bag/save, and the battle engine — damage, crit,
+accuracy, type chart, status, catch, exp. **Each formula carries a provenance
+citation to the Lua it ports.**
+
+The guest owns the RNG and the save. One guest turn per host tick:
+`frame(buttons)`, exactly once. The same code runs headless in Bun (for the
+sim and tests) and inside QuickJS on device — the module graph is
+transport-clean by design and bundles to a single IIFE (`game.js`).
+
+## The core owns the scene
+
+`pocketvoxel-core` is presentation only, zero gameplay. It is `no_std +
+alloc`, `f32` (libm on PSP), zero dependencies. Per frame it:
+
+- loads the VXPK and owns chunk meshes **zero-copy in place**, culling per
+  frame with a frustum over chunk AABBs;
+- retains what the guest drives through ops: camera, pitch rung, tint, up to
+  16 entity billboards, removable stamps, emotes, the battle stage, and a
+  retained GB UI tile grid (20×18) with a reveal counter for typewriter text;
+- resolves every textured draw's CLUT through one function,
+  `draw::resolve_pal` — the pak's per-map world palette, then the page's own
+  palette, then the `palette` op's SGB selection, then the page kind's GB
+  ramp. **Both hardware backends and the software rasterizer call the same
+  function**, so no two renderers can bind different colours for one draw;
+- builds one ordered draw list: sky bands → terrain chunks (each followed by
+  its own tree mesh at this rung's level of detail) → water → shadow decals →
+  player ghost (inverted depth, no write) → entity cards → grass → flowers →
+  GB UI quads.
+
+Backends consume that list and never touch list lifecycle. Adding a machine
+means adding a backend, **not forking the game** — the Vita port is a second
+backend and a second shell around the same core, same pak, same guest bundle.
+
+## The boundary is thin, and measured
+
+Steady-state traffic is **~10–40 ops per tick** (camera + moving entities + a
+text reveal counter); opening a menu bursts a few hundred `ui*` ops once.
+Against the measured QuickJS wall on a 333 MHz PSP — **~1.7 µs per op, ~8k
+ops per frame** — that is noise.
+
+Data crosses once, at boot: `gamedata()` returns the pak's GAME section
+(one cold JSON parse guest-side, then the guest never crosses for data
+again), and `audiodata()` returns the AUDI manifest's JSON half. The op
+vocabulary itself is pinned in `contracts/spec/voxel-spec.ts`, code-generated
+into Rust, and a **byte-compare drift guard** fails the build if the two ever
+disagree — see [The Voxel Surface](/reference/surface).
+
+## Audio: names in the guest, bytes in the core
+
+Sound is the ROM's own **channel programs** — short bytecode streams the GB
+sound driver interprets frame by frame. Pocket Voxel runs them in an
+interpreter in the Rust core (`pocketvoxel-core/src/audio.rs`, a port of
+gen1recomp's `ChipSynth.lua`) that renders straight to PCM. No register-level
+emulation: the interpreter tracks note, envelope, duty, vibrato, slide, sweep
+and noise LFSR per channel, and the four channels sum, divide by four and
+clamp.
+
+The split follows the runtime's one rule — **the guest owns names, the core
+owns bytes**:
+
+- `game/audio/banks.ts` resolves a song label, sfx name or species into the
+  numbers an audio op carries. `bank` is a *bank slot* — the ROM bank's index
+  in the manifest's `bankOrder` — and `addr` the program's GB address inside
+  its 0x4000-byte window.
+- `pocketvoxel-core/src/audio.rs` reads the program bytes in place out of the
+  pak's AUDI section. **The core parses no JSON and knows no name; the guest
+  reads no sample.**
+
+Why it lives core-side: measured on real hardware, one PCM frame of the
+interpreter cost **~0.21 ms in QuickJS** — 11.025 kHz wanted ~2.3 seconds of
+CPU per second of audio, collapsing the frame to ~9 fps. Compiled, the same
+interpreter renders a whole tick's 184 frames in ~6.5 µs on a desktop —
+extrapolated, **~2% of the 16.7 ms frame** on the PSP's Allegrex instead of
+230% of it.
+
+Correctness is held to a hard bar: rendered PCM is verified **sample-exact**
+against the unmodified reference `ChipSynth.lua` running under LuaJIT — all
+45 songs, 104 sound effects and 154 cries, ~200 million samples, zero
+differences. PCM leaves through the PocketJS `audio` module, not through the
+voxel surface; a host that pumps nothing runs the identical op stream silent.
+
+## Where to go deeper
+
+- The full design record, with every measurement and every rejected
+  alternative: [VOXEL.md](/VOXEL)
+- How the pak gets made: [The Asset Pipeline](/guide/pipeline)
+- How one pak serves three machines: [The Quality Ladder](/guide/quality-ladder)
+- The op vocabulary: [The Voxel Surface](/reference/surface)

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,119 @@
+# Getting Started
+
+This page takes you from a clean checkout to a cooked pak, verified goldens,
+and the game running in PPSSPP — no console hardware required. Device builds
+are covered in [Running on PSP](/guide/psp) and [Running on PS Vita](/guide/vita).
+
+## What you need
+
+| Tool | Needed for | Notes |
+| --- | --- | --- |
+| [Bun](https://bun.sh) ≥ 1.2 | everything | the importer, cooker, headless sim and test runner all run under Bun |
+| Rust (stable) + Cargo | `check`, `shots`, device builds | `pocketvoxel-sim` is a desktop crate; `cargo` must be on `PATH` |
+| LuaJIT | optional | the RED++ colour dump and the oracle tests; absent → the cooker prints a reason and cooks **without colour**, oracle suites skip |
+| [PPSSPP](https://www.ppsspp.org) (SDL build) | optional | `bun tools/voxel.ts run` launches the EBOOT; the e2e uses PPSSPP headless |
+| cargo-psp toolchain | PSP builds only | resolved and **pinned for you** by `tools/voxel.ts` — do not install your own |
+| VitaSDK + cargo-vita | Vita builds only | see [Running on PS Vita](/guide/vita) |
+
+## You bring the ROM
+
+The repository is **ROM-fed**: the only game-content input is a canonical US
+Gen-1 ROM you already own (Red, 1 MiB, SHA-1
+`ea9bcae617fdf159b045185467ae58b2e4a48b9a`). The importer verifies that hash
+before decoding a single byte. Everything decoded lands under git-ignored
+`dist/` and **no ROM-derived byte is ever committed** — no cooked pak, no
+extracted art, no decoded text. Rendering goldens are frame *hashes*, never
+pixels.
+
+Two **reference checkouts** are inputs the same way the ROM is:
+
+- [gen1recomp](https://github.com/bryanthaboi/gen1recomp) supplies
+  `tools/rom_manifest.json` (the symbol table the importer is driven by) and
+  `data/palettes_gbc.lua` (the RED++ colour pack — pokered-gbc-derived, MIT,
+  *not* ROM-derived).
+- [DramaticShapeVoxelMod](https://github.com/DramaticShape/DramaticShapeVoxelMod)
+  supplies `data/voxel_heights.lua` (tile class profiles, building templates)
+  and `data/battle_arenas.lua`.
+
+Anything that needs an input you don't have **skips with a printed reason**
+instead of failing into a half-decoded state. CI never sees the ROM or the
+checkouts — ROM-gated test suites skip there by design.
+
+## Clone and configure
+
+```sh
+git clone --recursive https://github.com/pocket-stack/pocket-voxel
+cd pocket-voxel && bun install
+```
+
+Forgot `--recursive`? Run `bun run setup` (it runs
+`git submodule update --init`). The engine arrives as a pinned submodule at
+`vendor/pocketjs`; the PSP host library, the audio module and the toolchain
+pins all come from that one engine commit.
+
+Then point the pipeline at its inputs:
+
+```sh
+export VOXELMON_ROM=/path/to/your/rom.gb        # SHA-1 verified before any decode
+export VOXELMON_G1R=~/code/gen1recomp           # default: ~/code/gen1recomp
+export VOXELMON_VOXELMOD=~/code/DramaticShapeVoxelMod  # default: ~/code/DramaticShapeVoxelMod
+```
+
+## First run of the pipeline
+
+```sh
+bun tools/voxel.ts import   # ROM → dist/voxelmon/gen/ (17 JSON datasets + gfx.bin + programs.bin)
+bun tools/voxel.ts cook     # gen/ → dist/voxelmon/voxelmon.vxpak
+bun tools/voxel.ts check    # replay both tapes, assert both rungs' frame hashes
+```
+
+`check` is the full acceptance path: it imports if `gen/` is missing,
+**always re-cooks** (a stale pak is the one failure that looks like an engine
+bug), runs the story and battle tapes headless in Bun to record op traces,
+then replays each trace through the real Rust core and software rasterizer at
+**both** pinned quality rungs, comparing frame hashes against the committed
+goldens. Green `check` means the whole pipeline — importer, cooker, guest,
+core, rasterizer — agrees with the committed picture.
+
+Where things land (all git-ignored):
+
+```text
+dist/voxelmon/gen/              imported datasets (JSON + gfx.bin + programs.bin)
+dist/voxelmon/voxelmon.vxpak    the cooked pak — the one artifact every machine loads
+dist/voxelmon/trace/*.vtrace    recorded op traces, one per tape
+dist/voxelmon/shots-*/          PNG frames, only when you ask for them
+```
+
+## See it, without hardware
+
+```sh
+bun tools/voxel.ts shots    # render PNG frames for every mark, both rungs
+bun tools/voxel.ts run      # build the EBOOT and launch it in PPSSPP
+bun tools/voxel.ts wav      # render any song/sfx/cry to dist/voxelmon/audio/*.wav
+```
+
+`shots` writes to `dist/voxelmon/shots-<tape>-<tier>/` — the reading material
+for judging a rung visually. `run` builds the PSP EBOOT and opens it in
+PPSSPP (macOS `open -a PPSSPPSDL`); PPSSPP maps the EBOOT's own directory as
+`host0:`, so the pak is found automatically.
+
+## Run the tests
+
+```sh
+bun test                        # 226 tests; ROM-gated suites skip with a reason
+bun tools/voxel.ts check        # both quality rungs' frame hashes
+bun tests/e2e/voxel-ppsspp.ts   # GE-vs-sim parity at 11 story marks
+```
+
+See [Testing & Determinism](/guide/testing) for what each layer proves.
+
+## Troubleshooting
+
+| Symptom | Cause / fix |
+| --- | --- |
+| `voxel import: skipped — …` | an input is missing or the ROM failed its SHA-1 gate. You need the **canonical US Red** ROM — other revisions and languages hash differently and are rejected before decode. |
+| cooker prints "cooking without colour" | LuaJIT or the gen1recomp checkout is absent, so the RED++ pack can't be dumped. The pak still cooks; the world renders in SGB palettes. |
+| `check` mismatches at the `-max` tier | the top rung stopped being the identity. **Never re-record `-max` goldens** — fix the dials. See [the golden ceremony](/guide/testing#the-golden-ceremony). |
+| ROM-gated tests skip | expected whenever `VOXELMON_ROM` / reference checkouts are absent — the `POCKET3D_TEST_MAPS` convention. CI always runs this way. |
+| `voxel vita: incomplete VitaSDK` / `libvitaGL.a missing` | set `VITASDK`, and run `vdpm vitaGL` — the build checks both before starting. |
+| a second worktree wants the pak | symlink `dist` — but note `.gitignore` lists both `/dist` and `dist/` **on purpose**, because a trailing slash matches directories only and a `dist` *symlink* would otherwise slip into a commit. |

--- a/docs/guide/pipeline.md
+++ b/docs/guide/pipeline.md
@@ -1,0 +1,131 @@
+# The Asset Pipeline
+
+Everything a machine renders comes out of one cooked file,
+`dist/voxelmon/voxelmon.vxpak`. The pipeline that produces it runs on your
+machine, once — the VoxelMod's analysis at cook time instead of every session
+on the handheld:
+
+```mermaid
+flowchart LR
+    inputs(["your ROM<br/><small>+ rom_manifest.json</small>"]) -->|"import · SHA-1 gated"| gen["dist/voxelmon/gen/<br/><small>17 datasets · gfx.bin · programs.bin</small>"] -->|"cook · 7 stages"| pak["voxelmon.vxpak<br/><small>VXPK v4 — one pak, every machine</small>"]
+```
+
+## Import: manifest-driven, SHA-1 gated
+
+`bun tools/voxel.ts import` is a TypeScript port of the gen1recomp extractor,
+driven by the same `rom_manifest.json` (3274 name→[bank,addr] symbol entries,
+charmap, per-map metadata). It is **manifest-driven, not offset-hardcoded** —
+the manifest is consumed verbatim rather than transcribing a megabyte of
+addresses. The SHA-1 gate runs before anything is decoded.
+
+What comes out, under `dist/voxelmon/gen/`:
+
+- **17 JSON datasets** with the same field names and record shapes as the Lua
+  tables, so parity diffing is mechanical (`maps.json`, `pokemon.json`,
+  `moves.json`, `encounters.json`, `text.json`, …).
+- **`gfx.bin`** — one blob of indexed bitmaps, 1 byte per pixel (`0..3` = GB
+  shade, `0xff` = transparent), with `gfx.json` as its directory. Graphics
+  never become PNGs in `gen/`.
+- **`programs.bin`** — the ROM's sound banks concatenated in `bankOrder`,
+  0x4000 bytes each: the windows the chip-synth interpreter reads through.
+
+Parity with the reference is testable, not assumed: the gen1recomp checkout's
+own Python extractor produces the same datasets independently, and
+`bun tools/voxel.ts parity` deep-compares all 16 datasets that have a
+reference counterpart, field for field. See
+[Data & Formats](/reference/formats) for shapes and normalization rules.
+
+## Cook: the voxelizer
+
+`bun tools/voxel.ts cook` runs seven stages (`voxelmon/cook/`):
+
+1. **Classify** every tile position — profile pins → cell rules → wall
+   fallback; the VoxelMod's class/height table ported verbatim
+   (`classify.ts`).
+2. **Measure volumes** — repeat-aware column heights, region consensus, roof
+   split — then match the 42 building templates and place pinned props
+   (`volumes.ts`, `buildings.ts`).
+3. **Mesh per 16×16-tile chunk** into GE-ready buffers: 16-byte vertices
+   (u16 fixed-point UVs, u32 colour, i16 positions), u16 indices, face shade
+   × baked AO folded into vertex colour, grass/flower/water split into their
+   own meshes, side faces cut into 8 px bands with cropped — never
+   stretched — art. Round scenery is meshed **three times**: the fine carved
+   hull, the same drawing carved at 2×2-px voxels (`treeCoarse`), and the
+   cells re-extruded as plain boxes (`treeBox`) — the levels the
+   [quality ladder](/guide/quality-ladder) picks between at runtime.
+4. **Pack atlases** as pre-swizzled CLUT8 — one terrain-atlas copy per
+   animation frame (water, flowers), so tile animation on device is a texture
+   bind, not a texel write. Day tint is a CLUT rewrite — the GB's own trick.
+5. **Bake RED++ colour** into the terrain page's texel index and resolve the
+   per-map/per-page bindings (`redpp.ts`, below).
+6. **Drop the faces no camera can reach** (the hidden-face cull, below).
+7. **Write the pak** — a MONPAK-style container: magic, section table,
+   16-byte alignment, validated zero-copy reader core-side. Sections carry
+   the chunks, atlases, palettes, colour bindings, the GAME section the guest
+   parses at boot, and the AUDI section with `audio.json` + `programs.bin`
+   verbatim. Layout details: [Data & Formats](/reference/formats).
+
+Determinism is a pipeline property: **two cooks of the same inputs are
+byte-identical.**
+
+## The hidden-face cull
+
+Every quad the cooker emits names the direction its front points in, and one
+rule decides what no camera can reach: **-Y faces (undersides) topping out at
+or below 24 world px are dropped.** A downward face is front-facing only when
+the eye is under it, and eye height depends on the camera rig alone, never on
+where the player stands — the lowest rig eye is 27.91 px.
+
+Measured effect: **5.2% of cooked quads and 4.6% of the pak** removed, with
+all 15 hash goldens byte-identical. `VOXEL_KEEP_HIDDEN=1` re-cooks a
+byte-identical pre-cull pak, which is how the rule is A/B'd.
+
+Two neighbouring ideas were measured and **rejected, and stay rejected**:
+north-facing walls are visible in the southern half of a top-down frame, and
+the camera-ward pull means grass/flower quads' cooked facing is not their
+drawn facing — culling either breaks goldens.
+
+::: warning The cull is a pak invariant
+Anything that lowers a camera eye below 24 px — a new rig, a smaller rig
+height, a sixth pitch rung — **invalidates the cooked pak**, not just the
+cooker. A free-roam camera deletes this optimisation; it does not work around
+it.
+:::
+
+## Per-tile colour (RED++ / pokered-gbc)
+
+pokered-gbc assigns one of 8 four-colour palettes to every tile graphic id of
+a tileset, swapping only the ROOF slot per town. The reference reaches those
+colours by CPU-recolouring the tileset atlas per map; Pocket Voxel reaches
+the same colours **without recolouring anything**, by moving the palette
+group into the texel index:
+
+```text
+texel = group * 4 + shade     // 0..31
+0xff  = transparent           // unchanged
+```
+
+8 groups × 4 shades = 32 of the CLUT's 256 entries, so the entire per-tile
+assignment fits inside the byte the page already stored: **zero delta** in
+page dimensions, texel count, fill rate, vertex count, draw calls and guest
+ops. Pallet Town's white roofs and Viridian's green roofs share one terrain
+page and cost one CLUT load each. The roof swap replaces only colours 1 and 2
+of the ROOF group, exactly as the GB's `LoadTownPalette` does.
+
+Parity is claimed **at the CLUT, not at the framebuffer** (baked AO × face
+shade means no pixel can match a flat 2D reference): the test runs
+gen1recomp's own `PaletteFX` under LuaJIT and compares all 2688 resolved
+colours against the cook. Where the reference model can't apply — per-map
+tile-id exceptions on a shared terrain page — the cooker **refuses to cook**
+rather than mis-colouring silently.
+
+## Cook-time flags
+
+| Flag | Effect |
+| --- | --- |
+| `VOXEL_KEEP_HIDDEN=1` | keep the culled undersides — the A/B switch for the hidden-face rule |
+| `VOXEL_TREE_BOXES=1` | carve nothing; boxes ride the terrain stream (the pre-LOD shape; such a pak renders its one tree level at every rung) |
+
+The pak states what it carries: a META flags word says whether chunks hold
+both tree levels, and the chunk record's extra mesh ranges bumped the VXPK
+version (3 → 4), so a stale pak is **rejected instead of mis-read**.

--- a/docs/guide/psp.md
+++ b/docs/guide/psp.md
@@ -1,0 +1,107 @@
+# Running on PSP
+
+The PSP is the primary target: a real PSP-2000 at 480×272, 30 fps present
+lock with 60 Hz game logic, sound through the ROM's own channel programs.
+
+## Build
+
+```sh
+bun tools/voxel.ts psp --release
+```
+
+Extra arguments pass through to `cargo psp` (e.g. `--features capture`).
+The command needs no toolchain setup of your own — the
+[cargo-psp](https://github.com/overdrivenpotato/rust-psp) toolchain is
+**resolved and pinned** by `tools/psp-toolchain.ts` from the vendored engine
+commit, so every checkout builds with the same rustc and the same SDK.
+
+What one build actually does:
+
+1. **Prepare** — import if `gen/` is missing, re-cook the pak, run both tapes
+   headless to refresh the traces.
+2. **Bundle the guest** — `voxelmon/game/psp-main.ts` → `dist/voxelmon/game.js`
+   via `bun build --format=iife --target=browser`: no module system, no
+   Bun/node APIs. The bundle is baked into the EBOOT by `build.rs`.
+3. **`cargo psp`** under the pinned toolchain.
+4. **Re-pack the PBP with `MEMSIZE=1`.** cargo-psp's `Psp.toml` has no field
+   for it, and without that flag a PSP grants only the 24 MB user partition —
+   which the pak plus the QuickJS heap cannot share. The tool writes the
+   PARAM.SFO itself (same layout, plus the one dword) and re-packs with the
+   XMB cover art preserved.
+5. **Copy the pak next to the EBOOT** — PPSSPP maps the EBOOT's directory as
+   `host0:`, so the emulator finds it with zero configuration.
+
+Output: `crates/pocketvoxel-psp/target/mipsel-sony-psp/release/EBOOT.PBP`
+with `voxelmon.vxpak` beside it.
+
+## Install on hardware
+
+Put `EBOOT.PBP` and `voxelmon.vxpak` together in one folder under
+`ms0:/PSP/GAME/` — that's the whole install.
+
+For development, [PSPLINK](https://github.com/pspdev/psplinkusb) is the loop
+that keeps the memory stick out of it: run the EBOOT over USB with the pak
+served from `host0:`, and every rebuild is a relaunch, not a copy.
+
+## Run in PPSSPP
+
+```sh
+bun tools/voxel.ts run   # build, then `open -a PPSSPPSDL <EBOOT>`
+```
+
+PPSSPP honors `MEMSIZE` from the PBP's PARAM.SFO. Note that **PPSSPP
+headless runs as a PSP-1000 (24 MB)** — the e2e accounts for this; if you
+script headless runs yourself, expect slim-model memory.
+
+## The capture build
+
+The e2e drives a special EBOOT that replays recorded input deterministically
+under PPSSPP and hashes what the GE actually rendered:
+
+```sh
+bun tools/voxel.ts psp --release --features capture
+```
+
+`VOXEL_CAP_INPUT` / `VOXEL_CAP_MARKS` name the recorded input and the marks
+to capture; `tests/e2e/voxel-ppsspp.ts` sets them for you and asserts
+GE-vs-rasterizer agreement at all 11 story marks within a measured pixel
+tolerance.
+
+## GE discipline
+
+Rules inherited from `pocket3d-gu` and const-asserted in the backend:
+
+- the pak's 16-byte vertex — u16 fixed-point UVs, u32 colour, **i16
+  positions** countered by a ×32768 model scale;
+- inverted 16-bit depth (`GreaterOrEqual`, clear 0), GL-style −1..1
+  projection;
+- dcache writeback after every CPU write the GE reads; pool reset only after
+  `sceGuSync`; 333 MHz set explicitly at boot.
+
+Two rules this runtime **bisected on real hardware** (both failure modes draw
+plausible-looking garbage, never crash):
+
+::: warning Textured TRANSFORM_3D draws must use the i16 + indexed vertex
+A textured `VERTEX_32BITF` card samples noise. Every billboard card and every
+CPU-staged mesh goes through the pak's own vertex format.
+:::
+
+::: warning CLUT8 atlas pages must be at least 64 px wide
+A 16-px-wide sprite sheet missamples into vertical-strip noise. The cooker
+pads sprite and emote pages; card U coordinates normalize by page width.
+:::
+
+## The frame is fetch-bound
+
+A finding worth internalizing before optimizing anything here: the GE on this
+content is **fetch-bound, and what it fetches from matters less than whether
+the CPU just wrote it**. Splicing index ranges through the frame pool looked
+~17 ms/frame faster than drawing in place — but a boot-time copy of the same
+bytes reproduced none of the win. The advantage was the *recency of the CPU
+writes*, and it cost ~25 ms of CPU to produce. The shipped backend draws
+index ranges **in place** (the cooker 16-byte-aligns each range) and spends
+no per-frame CPU on geometry at all.
+
+Consequence: performance work on this target means **geometry diets**
+(fewer bytes fetched per frame — see [the quality ladder](/guide/quality-ladder)),
+not draw-call or culling tricks.

--- a/docs/guide/quality-ladder.md
+++ b/docs/guide/quality-ladder.md
@@ -1,0 +1,126 @@
+# The Quality Ladder
+
+Pocket Voxel runs on machines an order of magnitude apart in throughput, so
+fidelity is a **ladder a machine climbs, not a build flag**. The rungs and
+their dials are pinned in `contracts/spec/voxel-spec.ts` (`QUALITY_TIER`,
+`QUALITY`); a host names its rung once with `quality(tier)` and the core
+applies that rung's dials while it builds every frame.
+
+Two rules make it a ladder and not a pile of switches:
+
+::: tip Rule 1 — every dial is a RUNTIME dial
+One cooked pak serves every rung. The rung is a **host** decision and never a
+re-cook — no op stream and no pak byte differs between a PSP and a desktop.
+Geometry that must differ per machine is cooked at *all* levels and picked
+between at runtime, and the pak declares which levels it carries, so a
+runtime asking for one it does not hold degrades instead of misrendering.
+:::
+
+::: tip Rule 2 — the top rung is the identity
+The top rung draws exactly what this runtime drew before the ladder existed.
+`tests/goldens/voxel/*-max.hashes` are the pre-ladder frame hashes, and
+`check` replays both tapes at the top rung against them byte-for-byte — so no
+later dial edit can quietly move the picture the ladder is supposed to
+preserve.
+:::
+
+Because the **host** names the rung, the guest bundle inside the Vita VPK is
+byte-identical to the one baked into the PSP EBOOT — no `#ifdef`, no second
+build of the game.
+
+## The dials
+
+All distances are world px from the view centre to a chunk's own centre,
+widened by the chunk's half-extent — one function, `draw::within_dist`, so a
+dial added later cannot measure differently from these.
+
+| rung | `grassDist` | `flowerDist` | `treeHullDist` | `treeCoarseDist` | `groundBakeDist` | `detailDensity` | `chunkDist` | `pullDepthBias` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `psp` (default) | unbounded | unbounded | off | unbounded | off (bake all) | 4 | 340 | on |
+| `vita` | unbounded | unbounded | unbounded | unbounded | unbounded (never) | 1 | 340 | off |
+| `desktop` | unbounded | unbounded | unbounded | unbounded | unbounded (never) | 1 | 340 | off |
+
+`chunkDist` is 2.5 view-heights at **every** rung including the top: it is
+the old hard-coded cull distance folded in — a pre-existing frame-budget cap,
+not a fidelity dial. Widening it at the top would draw *more* than the
+pre-ladder runtime instead of the same.
+
+The `vita` rung is currently a labelled placeholder owed a number from the
+machine itself — at these dials it is pixel-identical to the top rung across
+both tapes on the v1 maps.
+
+## The no-moving-boundary rule
+
+The psp rung shipped one afternoon with finite detail distances, a
+coarse/box tree boundary and a live-geometry bubble around the player — and
+**every one of them became a device-visible walking artifact the same day**.
+A distance boundary inside the visible field moves with each step, so the
+swap it hides plays as flicker (a tree ring twinkling coarse↔box), popping
+(grass at its fade line), or a jump (the road flipping baked↔live one cell
+ahead of the player).
+
+The rule this repo keeps: **no camera-relative representation change inside
+the visible field — it never ships.** The psp rung keeps one representation
+everywhere the frustum reaches and pays for the frame with **uniform** dials,
+which cannot flicker because they never switch:
+
+- **coarse-only trees** — the fine carve is off everywhere except the chunk
+  underfoot (see below), coarse hulls everywhere else;
+- **bake-everywhere ground** — never a distance-gated bubble;
+- **detail density** — `detailDensity: 4` draws a prefix of each chunk's
+  detail streams. The cook packs those streams *stratified* (round-robin by
+  within-cell rank, cells in bit-reversed order), so any prefix is a
+  spatially uniform sample. Packed row-major, "half density" had meant a bald
+  south half per chunk — not thinner grass;
+- **the coarse carve ships without its rear hemisphere** — a carved ball is
+  convex and the camera is always south of and above it, so its north faces
+  are self-occluded at every pitch rung. They were 25% of the coarse stream.
+
+Composition at the route-1 checkpoint under these dials: coarse trees 15.4k,
+keep 10.2k, grass 6.6k, bake 2.2k, flowers 1.5k — **~37k triangles against
+the ~40k that holds a 33.3 ms present**.
+
+## Why trees get three levels of detail
+
+A carved tree hull is ~700 quads per cell; the plain box the same cell
+extrudes to is under ten. At pitch rung 2, hulls were **55.7k of Pallet
+Town's 96.8k triangles** — more than terrain, grass, flowers and water
+together. So the cooker emits all three levels (fine carve / 2×2-px coarse
+carve / boxes) and `draw::build` picks one per chunk against the tree dials.
+
+`treeHullDist: 0` does **not** mean "no fine trees": `within_dist` widens
+every limit by the chunk's half-extent, so the chunk under the view centre —
+the tree the player stands next to, where 2-px quantisation would be most
+visible — keeps the fine carve at any non-negative dial. The result is a
+three-ring gradient: fine underfoot, coarse to the horizon (minus the rear
+hemisphere), boxes beyond the cap.
+
+## `pullDepthBias` — the one dial with a CPU story
+
+The mod's camera-ward pull displaces every pulled vertex toward the eye along
+its own ray — a depth trick whose screen position is unchanged by
+construction. On the PSP that displacement must be re-staged on the CPU every
+frame, and telemetry measured that restage at **65–73 ms of a ~100 ms Route-1
+seam frame** — the single largest line in the whole frame.
+
+With the dial on, grass and flowers draw their cooked vertices **in place**
+and the pull becomes one constant NDC-depth bias per mesh, folded into the
+projection matrix. The bias equals the geometric pull's depth shift exactly
+*at the camera focus* — the player's own cell, or the arena centre — which is
+precisely where grass-over-feet layering is a gameplay contract. Entity cards
+keep the geometric pull at every rung (four vertices each), and the top rung
+keeps it for everything, so the identity anchor never moves.
+
+## Where the frame went
+
+After the 2026-08-06 CPU work (autopilot phase telemetry over the story
+tape): guest JS 16–19 ms, draw-list build ~0.7 ms, CPU record ~0.5–1 ms, GE
+hidden under the guest's window, vblank ~5–8 ms. Pallet Town 102 → 81 ms, the
+Pallet↔Route-1 seam 129 → 68 ms, Route 1 128 → 54 ms, interiors 33 ms.
+
+The frame is now **GE-fetch-bound**: GE time scales with vertex/index bytes
+fetched per frame, so the next rungs down the ladder are geometry diets — the
+planned cook-time **ground bake** (low-relief chunks projected into one
+textured quad each), hull instancing, far-chunk impostors — not draw-call or
+culling tricks. The full accounting, including every measured plateau that
+placed each dial's value, is in [VOXEL.md §4a](/VOXEL).

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,0 +1,104 @@
+# Testing & Determinism
+
+The frame is a pure function of `(tick index, buttons)`. The tick clock is
+the only clock; tile animation and menu cursors derive from it. Everything on
+this page exists to keep that sentence true across four executables — the Bun
+headless sim, the Rust software rasterizer, the PSP's GE and the Vita's GXM.
+
+## The commands
+
+```sh
+bun test                        # 226 tests; ROM-gated suites skip with a reason
+bun tools/voxel.ts check        # the full acceptance path (below)
+bun tools/voxel.ts record       # re-record the SHIPPED-rung goldens only
+bun tools/voxel.ts shots        # PNG frames per mark, per rung — the reading material
+bun tools/voxel.ts parity       # importer output vs the reference extractor
+bun tests/e2e/voxel-ppsspp.ts   # GE-vs-rasterizer parity at 11 story marks
+```
+
+`check` = import-if-missing + **always re-cook** + run both tapes headless +
+rasterize each trace at **both** pinned rungs against the committed hashes.
+
+## Five layers of verification
+
+1. **Importer parity** — the TS importer's 16 datasets deep-compared,
+   field for field, against what gen1recomp's own Python extractor produces
+   from the same ROM.
+2. **Gameplay tests** — Bun suites porting the reference test semantics
+   (formula tables, timing budgets, collision/ledge/warp parity cases)
+   against the ROM-decoded dataset, plus a fixture dataset so CI runs
+   ROM-free.
+3. **Oracle runs** — the Lua reference executes headless under LuaJIT
+   (110/110 engine suites green on this ROM). Targeted modules are driven
+   with identical inputs and compared trace for trace. The audio oracle is
+   the strictest: rendered PCM must be **sample-exact** against the
+   unmodified reference synth — all 303 programs, ~200 million samples, zero
+   differences — *and* clear a loudness floor, because sample-exact silence
+   would still be a bug.
+4. **One tape, every host** — [intent tapes](/reference/formats#tape-intent-tapes)
+   drive the Bun sim, which records the per-frame op stream. `pocketvoxel-sim`
+   replays that stream through the real core + software rasterizer into frame
+   hashes (committed) and PNGs (local only). The capture EBOOT replays the
+   same recorded input under PPSSPP, and the GE must agree with the
+   rasterizer within a measured pixel tolerance at every story mark.
+5. **Two rungs, one tape** — a tape is a *guest* op stream and the quality
+   rung is a *host* decision, so every tape pins two golden files:
+   `<tape>.hashes` at the shipped `psp` rung, and `<tape>-max.hashes` at the
+   top rung.
+
+The marks: 11 story checkpoints and 4 battle checkpoints, each hashed at both
+rungs — 15 marks, 30 committed hash lines, zero committed pixels.
+
+## The golden ceremony
+
+The two golden files per tape have **opposite lifecycles**, and the
+distinction is the backbone of the whole regression story:
+
+- **`<tape>.hashes` (shipped rung)** legitimately move when a dial moves —
+  that is the point of recording them. `bun tools/voxel.ts record` rewrites
+  them. The discipline is the *accounting*: a change that moves them owes a
+  statement of **which marks moved, and why each one had to** — e.g. tree LOD
+  moved 1 story mark and all 4 battle marks; the depth-bias pull moved the 8
+  outdoor story marks, verified against shots and the PPSSPP e2e.
+- **`<tape>-max.hashes` (identity anchor)** are the pre-ladder frame hashes
+  and are **never re-recorded for a dial edit** — `record` refuses to write
+  them, only re-proves them. A mismatch there means the ladder's top rung
+  stopped being the identity, and the fix is the dials, never the file.
+
+Three events may legitimately re-base the identity anchor, and each **pays
+with a pixel-diff proof**:
+
+| Event | The proof it paid |
+| --- | --- |
+| a vertex **format** change | the 16-byte vertex (u16 UVs) moved 590 pixels across all fifteen max-tier frames, worst 0.195%, every one a texel-boundary flip |
+| a **pack order** change | the stratified detail-stream order moved 60 pixels across fifteen frames, every one on an equal-depth crossing line — and a rank-preserving order was tried first specifically to avoid the ceremony |
+| a **gameplay** change | the only event that moves *both* rungs for the same reason: the tape is intent, so a legitimately different op stream moves every hash downstream. The 2026-08-07 parity pass moved 3 of 15 marks and documented why each had to move — and the other twelve being byte-identical is itself evidence the remaining changes were behavioural, not pictorial |
+
+::: danger Never "fix" a red `-max` check by re-recording
+The failure message says so explicitly, because the wrong fix is obvious and
+cheap and the right one is not. If the top rung stopped drawing the
+pre-ladder picture, a dial is measuring differently — find it.
+:::
+
+## Tapes are intent, never frame counts
+
+A tape line is `walk u 3`, `press a`, `wait 30`, `mark route-1` — never "hold
+up for 47 frames". `walk` counts **landed** steps and releases the direction
+when `landed + in-flight == target`, so walks never overshoot and a
+turn-in-place is not a step. This is what lets one tape drive every host and
+survive timing changes that don't change behaviour.
+
+Both tapes run against a pinned seed (`STORY_SEED = 17` in `tools/voxel.ts`);
+their routes are plotted against it. The guest partitions **three seeded RNG
+streams** (route / ambience / battle) so ambience cannot perturb the route —
+a deliberate divergence from upstream's single stream, kept because changing
+the topology would move every committed hash to buy nothing a player could
+see.
+
+## What CI sees
+
+CI has no ROM and no reference checkouts, ever. ROM-gated suites skip with a
+printed reason (the `POCKET3D_TEST_MAPS` convention); the fixture dataset
+keeps the gameplay suites meaningful. Everything hash-based that CI *can*
+check, it checks — the contract drift guard, the fixture gameplay tests, and
+the toolchain pins.

--- a/docs/guide/vita.md
+++ b/docs/guide/vita.md
@@ -1,0 +1,114 @@
+# Running on PS Vita
+
+The Vita runs the **same guest bundle, the same cooked pak and the same
+core** as the PSP. What's new is a second backend for the one draw list
+(`crates/pocketvoxel-gxm`, raw SceGxm) and a second application shell around
+it (`crates/pocketvoxel-vita`). It rasterizes at native **960×544** while the
+logical viewport stays the PSP's 480×272 — the cameras, the UI layout and
+every golden are unchanged; only the pixel count moves.
+
+## Build
+
+Needs [VitaSDK](https://vitasdk.org) and
+[cargo-vita](https://github.com/vita-rust/cargo-vita), plus vitaGL's static
+library (the build checks for it and tells you the fix — `vdpm vitaGL`):
+
+```sh
+export VITASDK=~/vitasdk
+bun tools/voxel.ts vita --release        # → dist/voxelmon/voxelmon.vpk
+```
+
+Extra arguments pass to `cargo vita`. `--tier <psp|vita|desktop>` overrides
+the quality rung the shell asks the core for (default `vita`) — an A/B
+measurement knob, not a build variant; the guest bundle never changes.
+
+The Rust nightly comes from the vendored Vita host's own
+`rust-toolchain.toml` — one pinned source both this VPK and PocketJS build
+against, so they cannot drift into two nightlies.
+
+## Install: one file
+
+**The VPK carries the pak inside it** (read from `app0:` at runtime) and
+needs nothing else on the console:
+
+1. Copy `voxelmon.vpk` over (VitaShell's `SELECT` starts USB or FTP).
+2. Press `X` on it, confirm.
+
+That is the whole install. It also ships libvita2d's **precompiled GXM
+shaders**, so a stock HENkaku console does not need Sony's runtime shader
+compiler (`libshacccg.suprx`) the way most Vita 3D homebrew does.
+
+Buttons match the EBOOT: `CIRCLE` confirms, `CROSS` cancels, the left stick
+walks one axis at a time.
+
+## Why the shaders arrive precompiled
+
+There is no OpenGL on this machine. The native API, SceGxm, has **no
+fixed-function pipe at all** — every draw needs a compiled vertex/fragment
+program pair, and compiling on the console means the firmware module Sony
+does not install by default. So the backend brings programs that are already
+compiled: libvita2d's five, read out of `pocket3d-vita`'s `shaders/`
+directory — one copy, one attribution, the technique OpenStrike established.
+
+Two consequences shape the whole backend:
+
+- **The textured program carries no per-vertex colour**, so an opaque mesh
+  draws twice over the same indices — the texel, then the pak's baked AO
+  through the colour program with a `dst * src` blend. That pair is what one
+  `TextureEffect::Modulate` gets the GE for free.
+- The vertex attribute formats read the cooked 16-byte `PakVert` **in place,
+  with no repacking**: `S16` takes the i16 positions as integers (no ×32768
+  scale needed), `S16N` reads the fixed-point UVs as 0..1, `U8N` reads the
+  ABGR straight. One GPU buffer, two attribute offsets.
+
+## What the missing alpha test costs
+
+GXM has no alpha test, and precompiled shaders cannot `discard`. The GE cuts
+sprite art out with a hardware alpha test; here alpha resolves by blending
+and draw order, so the passes split by whether their art is cut out:
+
+| Pass | Behaviour on Vita |
+| --- | --- |
+| Solid geometry (terrain, all tree levels, water) | opaque, depth-written, takes its AO pass — silhouette is carved into the mesh, **nothing lost** |
+| Cut-out geometry (grass, flowers, billboards) | alpha-blended, depth-preserving, **no AO pass** — a texture-less multiply would darken transparent texels into visible rectangles; losing AO on a grass tuft is the cheaper error |
+| GB UI layer | 2D, drawn last, never depth-tested — blending is exactly what the GE's cutout produced, **nothing lost** |
+
+This is the one honest visual difference from the PSP picture. A vitaGL
+backend that reproduced the GE exactly was built first and then **removed**:
+vitaGL compiles even its fixed-function shaders on the console, which made
+`libshacccg.suprx` a hard prerequisite and broke the one-file install. It is
+recoverable from history if the cut-out fidelity is ever worth that.
+
+## Memory and the frame
+
+The shell composes inside vita2d's scene (vita2d owns process-level GXM: the
+context, shader patcher, render target, swap). With std, a real allocator and
+hundreds of megabytes, three things the PSP shell spends effort on are simply
+absent: no partition arithmetic (the pak is read into one aligned heap block
+and leaked), no pipelined present, no arena-pressure heuristic.
+
+The pak's vertex and index pools are copied **once** into GXM-mapped blocks —
+the GPU cannot read the heap — and that is the only copy the port makes.
+Atlas pages upload as `LinearStrided` textures (any width, no power-of-two
+envelope). Because GXM binds one palette per texture object and RED++ samples
+one page through several palettes within a frame, the CLUT is resolved on the
+CPU into a 24 MB-budgeted RGBA cache keyed by (page, frame, palette, tinted);
+eviction is **deferred three frames** so a texture is never freed while the
+GPU may still be reading it. Atlases sample POINT, so the art stays crisp at
+4× the pixels instead of blurring.
+
+## A boot that cannot fail silently
+
+A console has no console. Graphics come up **first**, before the pak and
+before QuickJS, and every later boot stage owns a colour:
+
+| Screen | Meaning |
+| --- | --- |
+| amber | pak not found |
+| magenta | pak failed validation |
+| grey | pools would not fit |
+| cyan | the guest threw (exception text on screen) |
+
+Every stage also appends to `ux0:data/voxelmon/boot.txt`, and the first
+frames log what they actually drew — so "running but blank" and "never got
+there" cannot look alike.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,140 @@
+---
+layout: home
+title: Pocket Voxel
+titleTemplate: A Game Boy RPG as a voxel diorama on real handhelds
+
+hero:
+  name: Pocket Voxel
+  text: A Game Boy RPG, carved into a voxel diorama.
+  tagline: One cooked pak, one guest bundle — running on a real PSP, a real PS Vita, and your desktop. Deterministic to the byte.
+  actions:
+    - theme: brand
+      text: Get Started
+      link: /guide/getting-started
+    - theme: alt
+      text: Architecture
+      link: /guide/architecture
+    - theme: alt
+      text: Design Record
+      link: /VOXEL
+
+features:
+  - icon: 🕹️
+    title: Hardware first
+    details: Every screenshot on this page is a capture from a real PSP-2000 over PSPLINK. The same build installs on a stock HENkaku Vita as a single VPK — no extra runtime, no shader compiler.
+    link: /guide/psp
+    linkText: Run it on a PSP
+  - icon: 🧊
+    title: One pak, many machines
+    details: Fidelity is a runtime ladder, not a build flag. The same pak serves the PSP rung, the Vita rung and the desktop identity rung — the host names its rung, the guest never knows.
+    link: /guide/quality-ladder
+    linkText: The quality ladder
+  - icon: 🔁
+    title: Inverted ownership
+    details: Game state lives in the TypeScript guest — world, battle, script VM, saves, RNG. The Rust core owns only the retained scene. Steady-state boundary traffic is ~10–40 ops per tick.
+    link: /guide/architecture
+    linkText: The split
+  - icon: 🎲
+    title: Deterministic to the byte
+    details: Two cooks are byte-identical. Intent tapes drive every host; committed goldens are frame hashes, and re-basing one is a ceremony that pays with a pixel-diff proof.
+    link: /guide/testing
+    linkText: Testing & determinism
+  - icon: 🎵
+    title: Sample-exact chip audio
+    details: The ROM's own sound programs, interpreted core-side and rendered to PCM. All 45 songs, 104 effects and 154 cries verified sample-exact against the reference — ~200 million samples, zero differences.
+    link: /guide/architecture#audio-names-in-the-guest-bytes-in-the-core
+    linkText: How audio works
+  - icon: 🔐
+    title: ROM-fed, never committed
+    details: The only game-content input is a ROM you already own, SHA-1 verified before one byte is decoded. Everything derived lands under git-ignored dist/ — no cooked pak, no extracted art, no pixels.
+    link: /guide/getting-started#you-bring-the-rom
+    linkText: The content boundary
+---
+
+<figure class="pv-hero-shot">
+  <img src="./shots/psp-pallet-town.png" alt="Pallet Town as a voxel diorama on a real PSP — carved trees, gabled roofs, an NPC and the player between the houses." />
+  <figcaption>Pallet Town on a PSP-2000 — carved tree hulls, template-matched buildings, baked ambient occlusion.</figcaption>
+</figure>
+
+<div class="pv-badges">
+  <span>226 tests</span>
+  <span>15 golden marks × 2 rungs</span>
+  <span>303/303 audio programs sample-exact</span>
+  <span>~37k triangles under a 33.3 ms present lock</span>
+  <span>480×272 logical · 960×544 on Vita</span>
+</div>
+
+## The same build, everywhere the ladder reaches
+
+<div class="pv-gallery">
+  <figure>
+    <img src="./shots/psp-bedroom.png" alt="The player's bedroom: bookshelves, bed, SNES and a potted plant, voxelized." />
+    <figcaption>The player's bedroom — pinned props from the mod's template tables.</figcaption>
+  </figure>
+  <figure>
+    <img src="./shots/psp-route-1.png" alt="Route 1: tall encounter grass, ledges, fences, and rows of carved trees." />
+    <figcaption>Route 1 — encounter grass, ledges, and the three-ring tree gradient.</figcaption>
+  </figure>
+</div>
+
+## One pipeline, three machines
+
+<div class="pv-pipeline">
+  <div class="pv-stage">
+    <div class="pv-stage-title">Cook time <span>Bun · your machine</span></div>
+    <div class="pv-node">
+      <b>import</b>
+      <small>ROM → <code>gen/</code> — SHA-1 gated, manifest-driven</small>
+    </div>
+    <div class="pv-arrow"><i>↓</i></div>
+    <div class="pv-node">
+      <b>cook</b>
+      <small>classify tiles · carve trees · match 42 building templates · bake AO &amp; colour · pack chunks</small>
+    </div>
+    <div class="pv-arrow"><i>↓</i></div>
+    <div class="pv-node pv-node-pak">
+      <b>voxelmon.vxpak</b>
+      <small>one cooked pak — every machine, every rung</small>
+    </div>
+  </div>
+  <div class="pv-flow"><i>➜</i></div>
+  <div class="pv-stage">
+    <div class="pv-stage-title">Run time <span>on the device</span></div>
+    <div class="pv-node">
+      <b>QuickJS guest</b>
+      <small>the gameplay port — one <code>frame(buttons)</code> per tick</small>
+    </div>
+    <div class="pv-arrow"><i>↓</i><em>~10–40 ops / tick</em></div>
+    <div class="pv-node">
+      <b>pocketvoxel-core</b>
+      <small>culling · camera rungs · retained scene · chip synth</small>
+    </div>
+    <div class="pv-arrow"><i>↓</i><em>one ordered draw list</em></div>
+    <div class="pv-machines">
+      <div class="pv-machine"><b>pocketvoxel-gu</b><small>PSP · sceGu</small></div>
+      <div class="pv-machine"><b>pocketvoxel-gxm</b><small>Vita · raw GXM</small></div>
+      <div class="pv-machine"><b>pocketvoxel-sim</b><small>desktop raster</small></div>
+    </div>
+  </div>
+</div>
+
+<div class="pv-pipeline-foot">
+
+The acceptance path: intent tapes drive the same run on every host, pinned by
+[15 golden marks × 2 quality rungs](/guide/testing) — committed as frame
+hashes, never pixels.
+
+</div>
+
+The gameplay is a TypeScript port of the [gen1recomp](https://github.com/bryanthaboi/gen1recomp)
+Lua engine running in an embedded QuickJS guest; the presentation is a Rust
+reimplementation of the [DramaticShape Voxel Mod](https://github.com/DramaticShape/DramaticShapeVoxelMod)
+diorama renderer. Both upstreams are MIT-licensed, and both serve as
+**executable specifications, not vendored code** — every ported formula cites
+the Lua it ports, and the reference implementations run under LuaJIT as
+oracles in the test suite.
+
+Pocket Voxel is a specialized runtime of [PocketJS](https://github.com/pocket-stack/pocketjs):
+the same `⟨ core, surface, guest ⟩` composition as OpenStrike, with the
+ownership split inverted. Start with the [architecture overview](/guide/architecture),
+or go straight to [getting the pipeline running](/guide/getting-started).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,82 @@
+# CLI — `tools/voxel.ts`
+
+One command drives the whole pipeline. Every subcommand is safe to re-run;
+anything missing an input **prints a reason and exits** rather than failing
+into a half-decoded state.
+
+```sh
+bun tools/voxel.ts <command> [args]
+```
+
+## Environment
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `VOXELMON_ROM` | the canonical US Red ROM (SHA-1 gated) | none committed |
+| `VOXELMON_G1R` | gen1recomp checkout — manifest, parity reference, RED++ pack | `~/code/gen1recomp` |
+| `VOXELMON_VOXELMOD` | DramaticShapeVoxelMod checkout — tile profiles, arenas | `~/code/DramaticShapeVoxelMod` |
+| `VITASDK` | VitaSDK root (Vita builds) | `~/vitasdk` |
+
+## Commands
+
+### Pipeline
+
+| Command | What it does |
+| --- | --- |
+| `import` | decode the ROM into `dist/voxelmon/gen/` (SHA-1 gated; 17 datasets + `gfx.bin` + `programs.bin`) |
+| `parity` | deep-compare `gen/*.json` against the reference extractor's output, field for field |
+| `cook` | voxelize + pack `dist/voxelmon/voxelmon.vxpak`; extra args pass to the cooker |
+| `sim` | run the story tape headless → `dist/voxelmon/trace/story.vtrace` |
+
+### Verdicts
+
+Each of these prepares first — import if `gen/` is missing, **always
+re-cook**, re-run both tapes (`story`, `battle`) at the pinned seed:
+
+| Command | What it does |
+| --- | --- |
+| `check` | rasterize both traces at **both** rungs and assert against the committed hashes: `<tape>.hashes` (shipped `psp` rung) and `<tape>-max.hashes` (the identity) |
+| `record` | rewrite the **shipped** goldens only, then re-prove — never rewrite — the `-max` identity anchor |
+| `shots` | write PNG frames to `dist/voxelmon/shots-<tape>-<tier>/`; `--tier <name>` picks one rung, default both |
+| `wav` | render any song/sfx/cry through the real core synth to `dist/voxelmon/audio/*.wav`, printing peak and RMS — so "it renders" and "it is audible" stay two different claims |
+
+### Device builds
+
+Both prepare the pak + traces and bundle the guest
+(`voxelmon/game/psp-main.ts` → one IIFE, no module system) before invoking
+cargo:
+
+| Command | What it does |
+| --- | --- |
+| `psp` | `cargo psp` under the **pinned** toolchain, then re-pack the PBP with `MEMSIZE=1` (full PSP-2000 memory — the pak + QuickJS heap cannot share the 24 MB partition) and copy the pak next to the EBOOT. Extra args go to cargo: `--release`, `--features capture` |
+| `run` | `psp`, then launch the EBOOT in PPSSPP (`open -a PPSSPPSDL`) |
+| `vita` | `cargo vita build vpk` on the nightly pinned by the vendored Vita host; packages the pak **inside** the VPK. `--tier <psp\|vita\|desktop>` names the rung the shell requests (default `vita`); other args go to cargo |
+
+## package.json aliases
+
+```sh
+bun run setup    # git submodule update --init
+bun run import   # = tools/voxel.ts import
+bun run cook     # = tools/voxel.ts cook
+bun run check    # = tools/voxel.ts check
+bun run shots    # = tools/voxel.ts shots
+bun run psp      # = tools/voxel.ts psp --release
+bun run vita     # = tools/voxel.ts vita --release
+bun run e2e      # = bun tests/e2e/voxel-ppsspp.ts
+bun test         # the whole suite
+bun run tsc      # typecheck, no emit
+```
+
+## Notes worth knowing
+
+- **Every verdict re-cooks.** A stale pak is the one failure that looks like
+  an engine bug; the re-cook is cheap insurance and cooks are byte-identical
+  anyway.
+- **The tape seed is pinned** (`STORY_SEED = 17`): both tapes' routes are
+  plotted against it. Changing it invalidates every committed hash.
+- **`record` cannot damage the identity.** It refuses to rewrite
+  `-max.hashes` by construction; a red `-max` after `record` means a dial
+  broke the identity rung — see
+  [the golden ceremony](/guide/testing#the-golden-ceremony).
+- The cook flags (`VOXEL_KEEP_HIDDEN=1`, `VOXEL_TREE_BOXES=1`) are documented
+  in [The Asset Pipeline](/guide/pipeline#cook-time-flags).

--- a/docs/reference/formats.md
+++ b/docs/reference/formats.md
@@ -1,0 +1,154 @@
+# Data & Formats
+
+Every format the pipeline hands off through, in pipeline order. The source of
+truth for the byte layouts is `contracts/spec/voxel-spec.ts`; for the data
+interfaces, `voxelmon/SCHEMA.md` in the repo.
+
+## `dist/voxelmon/gen/` — the imported dataset
+
+One JSON file per gen1recomp `data/generated` module, **same field names and
+record shapes as the Lua tables** so parity diffing is mechanical:
+
+```text
+constants, tilesets, maps, font, sprites, moves, items, type_chart,
+palettes, pokemon, trainers, encounters, text, text_pointers,
+trainer_headers, field, audio
+```
+
+Normalization rules (Lua → JSON):
+
+- Lua arrays (dense `1..n`) become JSON arrays, order preserved — **every
+  index shifts down by one**; consumers index 0-based.
+- Map-shaped tables become objects; numeric keys become strings.
+- Absent optional fields are omitted, never `null`.
+- No floats are introduced; integers stay integers.
+
+**Graphics** don't become PNGs. `gen/gfx.bin` is one blob of indexed
+bitmaps — 1 byte per pixel: `0..3` = GB shade (0 = lightest), `0xff` =
+transparent — and `gen/gfx.json` is its directory (offset, width, height per
+key, keys mirroring the upstream asset paths). `shots --gen` can dump any
+entry to a local PNG for eyeballing.
+
+**Sound** is two files. `gen/programs.bin` is the ROM's sound banks
+concatenated in `bankOrder`, 0x4000 bytes each. `gen/audio.json` is the
+manifest: `songs` / `sfx` / `cries` (name → bank, address, engine),
+`mapSongs`, `battle`, `waveBanks`, `noiseHeaders`. `cries` is keyed by
+internal species slot — 154 entries, the 151 dex species plus the three
+cry-owning glitch slots.
+
+`gen/palettes_gbc.json` is the one file the importer does *not* produce: the
+cooker dumps the gen1recomp checkout's `palettes_gbc.lua` through a LuaJIT
+one-shot, re-dumping whenever the source is newer. Index bases after the
+dump are pinned by a test — getting them wrong recolours the world by one
+group and never throws.
+
+## `.tape` — intent tapes {#tape-intent-tapes}
+
+`voxelmon/tapes/*.tape`: one command per line, `#` comments. Tapes describe
+**intent, never frame counts**:
+
+```text
+walk <u|d|l|r> <cells>     # hold the direction until that many steps LAND
+press <a|b|start|select|u|d|l|r>   # tap: one tick down, then released
+wait <ticks>
+mark <name>                # checkpoint: the sim renders + hashes here
+```
+
+A turn-in-place is not a step; `walk` counts landed steps and releases the
+direction when `landed + in-flight == target`, so walks never overshoot.
+
+## `.vtrace` — the op trace
+
+The Bun headless run records everything that crossed the boundary;
+`pocketvoxel-sim` replays it through the real core and rasterizer. Text,
+line-oriented, at `dist/voxelmon/trace/<name>.vtrace`:
+
+```text
+voxtrace 1
+t <tick> <buttons>          # starts a tick; buttons = VOX_BTN mask that tick
+o <code> <i32> <i32> ...    # one op, numeric args in order
+s <code> <i32> <i32> <json-string>   # ops carrying a string arg
+m <name>                    # checkpoint marker: sim renders + hashes here
+```
+
+Ticks are contiguous from 0. At every `m` the sim appends
+`<name> <fnv1a64-of-rgba>` to its hash report; `--shots` writes the PNG
+locally. **Committed goldens are the hash lines only** — each tape pins
+`<tape>.hashes` (shipped rung) and `<tape>-max.hashes` (the identity;
+never re-recorded).
+
+## `voxelmon.vxpak` — the cooked pak
+
+A MONPAK-style container: magic, section table, 16-byte alignment, and a
+validated **zero-copy** reader core-side. Current version: **4** (version 3
+paks lack the two extra tree-LOD mesh ranges per chunk and are rejected
+instead of mis-read). A META flags word states what the pak carries — e.g.
+`VXPK_META_FLAG_TREE_LOD` — so a runtime never guesses.
+
+| Section | Carries |
+| --- | --- |
+| META | version, flags, counts |
+| CHNK | per-chunk mesh directory: terrain, grass, flower, water, stamp ranges — plus the tree hull / coarse / box ranges the rung picks between |
+| ATLS | pre-swizzled CLUT8 atlas pages, one terrain copy per animation frame |
+| VPAL | the palette list: 4 kind defaults, 37 SGB SuperPalettes, then the RED++ tail (world CLUTs, OBJ, pic). **The prefix never moves** |
+| VCOL | per-map and per-page colour bindings (below) |
+| STMP | removable sub-meshes (cut trees, boulders) toggled by the `stamp` op |
+| CMAP | the charmap: glyph → UI tile code |
+| GAME | the gameplay dataset the guest parses once at boot |
+| AUDI | `audio.json` + `programs.bin`, verbatim |
+
+### VCOL, the per-tile colour bindings
+
+The cooker bakes the RED++ palette group into the terrain page's texel index
+(`texel = group * 4 + shade`, `0xff` transparent) and VCOL says which VPAL
+entry each draw resolves that index through:
+
+```text
+ 0  u16 version = 1
+ 2  u16 map_count        == the CHNK map count
+ 4  u16 page_count       == the ATLS page count
+ 6  u16 flags            bit0 = the terrain page is group-baked
+ 8  u32 pad = 0 | 12 u32 pad = 0
+16  map_count  * 8 : u32 map_id | u16 world_pal | u16 terrain_page
+..  page_count * 2 : u16 page_pal
+```
+
+`0xffff` (`COLOR_PAL_NONE`) anywhere means "no binding — legacy path". Map
+records carry `map_id` explicitly, so the section is order-independent, and
+the core range-validates every index. A pak cooked *without* the colour pack
+still writes the section, all indices `COLOR_PAL_NONE`, and renders exactly
+as a pre-colour pak did.
+
+### GAME and AUDI
+
+**GAME** packs the gameplay subset of `gen/` as JSON bytes, plus two
+cook-time products: `atlas` (page-index maps) and `mapPalette` (map →
+SGB palette — the static port of pokered's `SetPal_Overworld` rule). The
+guest calls `gamedata()` once and never crosses for data again. In Bun the
+same object loads straight from `gen/` — one loader, two transports.
+
+**AUDI** is a 16-byte header (`u32 json_len | u32 program_len | pad`), the
+JSON manifest, then the program banks at the next 16-byte boundary. The
+guest parses only the JSON half; the core reads the program bytes in place
+(`Pak::audio_programs`). Every audio op names a bank by its **slot** in
+`bankOrder` — the window's position in the concatenation.
+
+## UI tile ids {#ui-tile-ids}
+
+`uiTile`/`uiFill` values and CMAP's outputs **are** the GB tile codes: the
+cooker packs the UI atlas so font glyphs sit at their charmap codes
+(`0x80..0xff`) and the border/arrow/HP-bar tiles at `0x60..0x7f`. Tile id 0
+is transparent (cell unset). Multi-character charmap entries (`'s` and
+friends — one glyph to the game, two characters to a string) get minted code
+points at `LIGATURE_BASE`, so the string that crosses the boundary is
+**cell-exact**.
+
+## The vertex
+
+The cooked vertex is **16 bytes**: u16 fixed-point UVs (÷32768), u32 ABGR
+(face shade × baked AO), i16 positions + pad. Every backend reads it in
+place — the GE with a ×32768 model scale, GXM as `S16`/`S16N`/`U8N`
+attributes at two offsets into one buffer, the rasterizer directly. Changing
+this format is the canonical identity-anchor re-basing event and pays for
+itself with a pixel-diff proof — see
+[the golden ceremony](/guide/testing#the-golden-ceremony).

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,33 @@
+# Glossary
+
+This project has a working vocabulary of its own. Terms link to the page
+that owns them.
+
+| Term | Meaning |
+| --- | --- |
+| **guest** | the TypeScript game running in QuickJS (in Bun when headless). Owns the game state, the RNG and the save. [Architecture](/guide/architecture) |
+| **core** | `pocketvoxel-core`, the Rust scene library. Owns only presentation: chunks, entities, cameras, the draw list, the chip synth. |
+| **surface** | the pinned op vocabulary between guest and core. [The Voxel Surface](/reference/surface) |
+| **op** | one numeric call across the boundary (`cam`, `ent`, `uiTile`, …). Steady state is ~10–40 per tick. |
+| **backend** | a consumer of the core's ordered draw list: `pocketvoxel-gu` (PSP GE), `pocketvoxel-gxm` (Vita), the sim's software rasterizer. |
+| **pak** | `voxelmon.vxpak` — the one cooked artifact every machine loads. [Data & Formats](/reference/formats) |
+| **cook** | the offline voxelizer run: classify → volumes → mesh → atlas → colour → cull → pack. Byte-deterministic. [The Asset Pipeline](/guide/pipeline) |
+| **rung** | one step of the quality ladder (`psp` / `vita` / `desktop`), named by the **host** at boot — never by the guest, never a re-cook. [The Quality Ladder](/guide/quality-ladder) |
+| **dial** | one runtime fidelity setting inside a rung (`treeHullDist`, `detailDensity`, …). All distances measure through one function. |
+| **identity (rung / anchor)** | the top rung, which must draw exactly the pre-ladder picture; `*-max.hashes` pin it and are never re-recorded for a dial edit. |
+| **tape** | an intent script (`walk`, `press`, `wait`, `mark`) — never frame counts. One tape drives every host. [Formats](/reference/formats#tape-intent-tapes) |
+| **trace / `.vtrace`** | the recorded op stream a headless run produced; what the sim replays through the real core. |
+| **mark** | a named checkpoint in a tape where the sim renders and hashes a frame. 11 story + 4 battle. |
+| **golden** | a committed frame hash (fnv1a64 of RGBA). Never a pixel. |
+| **the ceremony** | what re-basing the identity goldens costs: a named legitimate event plus a pixel-diff proof. [Testing](/guide/testing#the-golden-ceremony) |
+| **no-moving-boundary rule** | no camera-relative representation change inside the visible field ships — moving boundaries play as flicker on device. |
+| **bank slot** | how audio ops name a ROM bank: its index in the manifest's `bankOrder`, i.e. the position of its 0x4000-byte window in `programs.bin`. |
+| **channel program** | the GB sound driver's bytecode for one channel; the core interprets these to PCM directly — no register emulation. |
+| **RED++ / pokered-gbc** | the per-tile colour model, baked into the terrain texel index at cook time (`texel = group*4 + shade`). |
+| **SuperPalette** | one named SGB four-colour palette from the RED++ pack; the pak carries 37 plus the RED++ tail. |
+| **stamp** | a pre-cooked removable sub-mesh (cut tree, moved boulder) the guest toggles at runtime. |
+| **ghost** | the player's occluded silhouette, drawn with an inverted depth test and no depth write. |
+| **oracle** | the unmodified Lua reference running under LuaJIT, used as ground truth — trace-for-trace for gameplay, sample-exact for audio. |
+| **capture EBOOT** | the `--features capture` build that replays recorded input under PPSSPP and hashes what the GE drew — the hardware half of the e2e. |
+| **manifest-driven** | the importer reads gen1recomp's `rom_manifest.json` (symbols, charmap, map metadata) instead of hardcoding offsets. |
+| **content boundary** | the legal line: ROM-derived bytes live only under git-ignored `dist/`, verified by SHA-1 before any decode. [Getting Started](/guide/getting-started#you-bring-the-rom) |

--- a/docs/reference/surface.md
+++ b/docs/reference/surface.md
@@ -1,0 +1,97 @@
+# The Voxel Surface
+
+The op vocabulary the guest drives the scene with. It is pinned in
+`contracts/spec/voxel-spec.ts` — the single source of truth — code-generated
+into Rust (`contracts/spec/gen-voxel-rust.ts` → `spec.rs`), and guarded by a
+**byte-compare drift test**: if the checked-in Rust ever disagrees with what
+the spec generates, the build fails. Changing the surface is therefore a
+three-step ceremony: edit the spec, regenerate, commit both.
+
+Steady-state traffic is ~10–40 ops per tick. Every op argument is a number;
+strings cross only in `uiText` (and are resolved core-side through the cooked
+charmap).
+
+## world
+
+| Op | Semantics |
+| --- | --- |
+| `mapShow(slot, mapId, ox, oy)` | show a map in a slot: 0 = current, 1..4 = connected neighbours at their seam offsets |
+| `mapHide(slot)` | drop a slot |
+| `cam(x, y)` | move the view centre |
+| `pitch(rung)` | pick a rung on the pitch ladder (0/15/35/50/75°) |
+| `tint(abgr)` | day tint — resolved as a CLUT rewrite, the GB's own trick |
+| `stamp(mapId, cx, cy, on)` | toggle a pre-cooked removable sub-mesh: the cut tree, the moved boulder |
+| `palette(index)` | the map's SGB SuperPalette. On a RED++-cooked pak the per-map VCOL bindings outrank this op entirely — and **the guest emits the identical stream either way**: which colour model a build uses is decided by the cook, never by the guest |
+
+## entities
+
+| Op | Semantics |
+| --- | --- |
+| `ent(slot, sheet, frame, x, y, lift, flags)` | place/update one of 16 billboards. Cards lean back by camera pitch and pull toward the eye along each vertex's own ray — the mod's projection-invariant depth bias, ported exactly |
+| `entHide(slot)` | hide a billboard |
+| `emote(slot, kind)` | the exclamation/heart/sleep bubble over an entity |
+
+## ui
+
+The GB UI is a retained 20×18 tile layer composited over the diorama, scaled
+to fit 480×272. Tile ids **are** the GB tile codes (see
+[Data & Formats](/reference/formats#ui-tile-ids)).
+
+| Op | Semantics |
+| --- | --- |
+| `uiTile(x, y, tile)` | set one cell |
+| `uiFill(x, y, w, h, tile)` | fill a rect |
+| `uiText(x, y, str)` | **one live run** — the core retains only the last `uiText`; it exists for the row being typed. Finished rows are stamped into the grid as tiles (glyph codes are tile ids) |
+| `uiReveal(n)` | the typewriter counter for the live run |
+| `uiClear()` | clear the layer |
+
+## battle
+
+Battles stage **on the map** — nothing moves the player; the camera goes to
+the arena, exactly as upstream.
+
+| Op | Semantics |
+| --- | --- |
+| `arena(mapId, x, y, shape, rig)` | stage the battle arena |
+| `card(side, pic, x, y)` / `cardHide(side)` | the two battle pics |
+| `battleCam(orbit, pitch, zoom)` | drive the solved rig (tele / wide — the mod's constants) |
+| `arenaEnd()` | tear the stage down |
+
+## audio
+
+Every argument is a number the guest resolved out of the AUDI manifest:
+`bank` is a **bank slot** (that ROM bank's index in `bankOrder`) and `addr`
+the program's GB address inside its 0x4000-byte window. The core parses no
+JSON and knows no name; the guest reads no sample.
+
+| Op | Semantics |
+| --- | --- |
+| `music(bank, addr, engine, flags)` | start a song |
+| `musicStop()` / `musicFade(ticks)` | stop / fade |
+| `sfx(bank, addr, engine, pitch, tempo, flags)` | one-shot effect |
+| `cry(bank, addr, engine, pitch, length)` | a species cry |
+| `audioWaves(engine, bank, addr)` | boot-time wave-table pin |
+| `audioDrum(engine, drum, bank, addr)` | boot-time drum-table pin |
+
+PCM itself leaves through the PocketJS `audio` module
+(capability `audio.pcm`), not through this surface: the host pumps
+`Scene::render_audio` for exactly the frames its ring wants. A host that
+pumps nothing runs the identical op stream silent.
+
+## system
+
+| Op | Semantics |
+| --- | --- |
+| `gamedata()` | returns the pak's GAME section at boot — one cold JSON parse, then the guest never crosses for data again |
+| `audiodata()` | the AUDI section; the guest parses only its JSON half — the program bytes stay in the pak where the core reads them |
+| `stats()` | frame counters |
+| `reset()` | reset the scene |
+| `quality(tier)` | the host names its [quality rung](/guide/quality-ladder), once, at boot |
+
+## events
+
+The core→guest channel is the standard packed batch wire
+(`u16 kind | u16 a | i32 b | i32 c | i32 d`) with **no kinds defined yet** —
+the core currently states no fact the guest does not already know. The
+channel exists so mesh-streaming or host-side timing facts can append later
+without a wire change.

--- a/package.json
+++ b/package.json
@@ -22,12 +22,18 @@
     "web:e2e": "bun web/scripts/e2e-chrome.ts",
     "e2e": "bun tests/e2e/voxel-ppsspp.ts",
     "test": "bun test tests/",
-    "tsc": "bunx tsc --noEmit -p . && bunx tsc --noEmit -p worker/tsconfig.json"
+    "tsc": "bunx tsc --noEmit -p . && bunx tsc --noEmit -p worker/tsconfig.json",
+    "docs:dev": "vitepress dev docs",
+    "docs:build": "vitepress build docs",
+    "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {
     "@types/bun": "^1.2.0",
     "@types/three": "^0.185.0",
+    "mermaid": "^11.16.1",
     "typescript": "^5.7.0",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-mermaid": "^2.0.17",
     "wrangler": "4.120.1"
   },
   "dependencies": {


### PR DESCRIPTION
## What this is

A developer-facing docs site under `docs/`, built with VitePress. It is a
**readable layer over the existing record, not a rewrite**: `docs/VOXEL.md`
is untouched and joins the nav as the Design Record; the byte-layout truth
stays in `contracts/spec/voxel-spec.ts` and `voxelmon/SCHEMA.md`, and the new
pages summarize and link instead of forking facts.

## Contents

- **Home** — hero + hardware captures, stat badges, the cook/run pipeline as
  an HTML two-panel diagram hinged on the pak node.
- **Guide** (7 pages) — getting started, architecture, asset pipeline,
  quality ladder, PSP, Vita, testing & determinism. Distilled from VOXEL.md,
  SCHEMA.md and `tools/voxel.ts` (not restated from the README), with mermaid
  diagrams where the record drew ascii boxes.
- **Reference** (4 pages) — the `tools/voxel.ts` commands, the surface op
  vocabulary, data & formats (`.tape` / `.vtrace` / VXPK sections), and a
  glossary of the project's invented vocabulary.
- **Contributing** — the hard rules collected in one place (content boundary,
  identity anchor, no-moving-boundary, the 24 px cull invariant, formula
  provenance, spec codegen). Two items are newly codified rather than quoted
  from the record: the "golden accounting goes in the PR" convention, and the
  docs-layering rule itself.
- **CI** — `.github/workflows/docs.yml` deploys to GitHub Pages on push to
  main (docs paths). Needs Pages → Source: "GitHub Actions" set once; the
  build needs no submodules, no ROM, no reference checkouts.

## Decisions worth reviewing

- Where VOXEL.md disagrees with itself, the site follows the newest state:
  the **16-byte v8 vertex** (§7 ceremony, §12 PakVert) rather than the stale
  20-byte wording of §2/§6/§9. Pak-size figures are deliberately not restated
  anywhere.
- The VitePress config is `config.mts` because the package declares no
  `"type": "module"` and vitepress is ESM-only.
- Mermaid renders client-side (~1 MB lazy chunk on diagram pages only); the
  theme CSS keeps `.vp-doc` typography from leaking into diagram labels.

## Try it

```sh
bun install
bun run docs:dev      # live
bun run docs:build    # what CI runs; validates links
```