### PR TITLE
ci(docs): add a dedicated Wrangler deployment config

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tsc": "bunx tsc --noEmit -p . && bunx tsc --noEmit -p worker/tsconfig.json",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
+    "docs:deploy": "wrangler deploy --config wrangler.docs.jsonc",
     "docs:preview": "vitepress preview docs"
   },
   "devDependencies": {

--- a/wrangler.docs.jsonc
+++ b/wrangler.docs.jsonc
@@ -1,0 +1,10 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "pocket-voxel",
+  "compatibility_date": "2026-08-21",
+  "assets": {
+    "directory": "./docs/.vitepress/dist",
+    "not_found_handling": "404-page",
+    "html_handling": "auto-trailing-slash"
+  }
+}


### PR DESCRIPTION
## Summary

- add a dedicated Wrangler config for the documentation deployment
- point static assets at `docs/.vitepress/dist`
- add `docs:deploy` so Workers Builds does not read the game Web Worker config
- leave the existing `wrangler.jsonc` and game deployment unchanged

## Cloudflare build settings

- Build command: `bun run docs:build`
- Deploy command: `bun run docs:deploy`
- Root directory: `/`

## Verification

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run docs:build`
- `bun run docs:deploy -- --dry-run`